### PR TITLE
✨[Feat] 회원 기능 구현

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -35,6 +35,17 @@ dependencies {
 	// Swagger
 	implementation 'org.springdoc:springdoc-openapi-starter-webmvc-ui:2.7.0'
 	implementation 'org.springdoc:springdoc-openapi-starter-webmvc-api:2.7.0'
+
+	// Security
+	implementation 'org.springframework.boot:spring-boot-starter-security'
+	testImplementation 'org.springframework.security:spring-security-test'
+	implementation 'org.springframework.boot:spring-boot-starter-oauth2-client'
+	implementation 'org.springframework.boot:spring-boot-starter-validation'
+
+	// JWT
+	implementation 'io.jsonwebtoken:jjwt-api:0.11.5'
+	runtimeOnly 'io.jsonwebtoken:jjwt-impl:0.11.5'
+	runtimeOnly 'io.jsonwebtoken:jjwt-jackson:0.11.5'
 }
 
 tasks.named('test') {

--- a/src/main/java/com/stockpulse/stockpulseAPI/domain/member/repository/MemberRepository.java
+++ b/src/main/java/com/stockpulse/stockpulseAPI/domain/member/repository/MemberRepository.java
@@ -1,0 +1,10 @@
+package com.stockpulse.stockpulseAPI.domain.member.repository;
+
+import com.stockpulse.stockpulseAPI.domain.member.entity.Member;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.Optional;
+
+public interface MemberRepository extends JpaRepository<Member, Long> {
+    Optional<Member> findByEmail(String email);
+}

--- a/src/main/java/com/stockpulse/stockpulseAPI/domain/token/controller/TokenController.java
+++ b/src/main/java/com/stockpulse/stockpulseAPI/domain/token/controller/TokenController.java
@@ -1,0 +1,38 @@
+package com.stockpulse.stockpulseAPI.domain.token.controller;
+
+import com.stockpulse.stockpulseAPI.domain.token.service.TokenService;
+import com.stockpulse.stockpulseAPI.global.apiPayload.ApiResponse;
+import com.stockpulse.stockpulseAPI.global.security.authDTO.AuthResponseDTO;
+import io.swagger.v3.oas.annotations.Operation;
+import jakarta.servlet.http.HttpServletRequest;
+import lombok.RequiredArgsConstructor;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/api/token")
+public class TokenController {
+
+    private final TokenService tokenService;
+
+    @Operation(
+            summary = "JWT Access Token 재발급 API",
+            description = "Refresh Token 을 검증하고 새로운 Access Token 과 Refresh Token 을 응답합니다.")
+    @PostMapping("/reissue")
+    public ApiResponse<AuthResponseDTO.TokenResponse> reissueToken(final HttpServletRequest request) {
+        AuthResponseDTO.TokenResponse tokenResponse = tokenService.reissueToken(request);
+
+        return ApiResponse.onSuccess(tokenResponse);
+    } // Access Token 재발급
+
+    @Operation(
+            summary = "로그아웃 API",
+            description = "Refresh Token을 삭제합니다.")
+    @GetMapping("/logout")
+    public void logout(final HttpServletRequest request) {
+        tokenService.deleteToken(request);
+    } // 로그아웃
+}

--- a/src/main/java/com/stockpulse/stockpulseAPI/domain/token/domain/Token.java
+++ b/src/main/java/com/stockpulse/stockpulseAPI/domain/token/domain/Token.java
@@ -1,0 +1,31 @@
+package com.stockpulse.stockpulseAPI.domain.token.domain;
+
+import jakarta.persistence.*;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Entity
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@Getter
+public class Token {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @Column(nullable = false, unique = true)
+    private String refreshToken;
+
+    @Column(nullable = false, unique = true)
+    private Long memberId;
+
+    public Token(final String refreshToken, final Long memberId) {
+        this.refreshToken = refreshToken;
+        this.memberId = memberId;
+    }
+
+    public void changeToken(final String refreshToken) {
+        this.refreshToken = refreshToken;
+    }
+}

--- a/src/main/java/com/stockpulse/stockpulseAPI/domain/token/repository/TokenRepository.java
+++ b/src/main/java/com/stockpulse/stockpulseAPI/domain/token/repository/TokenRepository.java
@@ -1,0 +1,12 @@
+package com.stockpulse.stockpulseAPI.domain.token.repository;
+
+import com.stockpulse.stockpulseAPI.domain.token.domain.Token;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.Optional;
+
+public interface TokenRepository extends JpaRepository<Token, Long> {
+    Optional<Token> findByRefreshToken(String refreshToken);
+
+    Optional<Token> findByMemberId(Long memberId);
+}

--- a/src/main/java/com/stockpulse/stockpulseAPI/domain/token/service/TokenService.java
+++ b/src/main/java/com/stockpulse/stockpulseAPI/domain/token/service/TokenService.java
@@ -1,0 +1,70 @@
+package com.stockpulse.stockpulseAPI.domain.token.service;
+
+import com.stockpulse.stockpulseAPI.domain.member.repository.MemberRepository;
+import com.stockpulse.stockpulseAPI.domain.token.domain.Token;
+import com.stockpulse.stockpulseAPI.domain.token.repository.TokenRepository;
+import com.stockpulse.stockpulseAPI.global.security.authDTO.AuthResponseDTO;
+import com.stockpulse.stockpulseAPI.global.security.converter.AuthConverter;
+import com.stockpulse.stockpulseAPI.global.security.exception.AuthException;
+import com.stockpulse.stockpulseAPI.global.security.provider.JwtTokenProvider;
+import jakarta.servlet.http.HttpServletRequest;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.Optional;
+
+import static com.stockpulse.stockpulseAPI.global.apiPayload.code.status.ErrorStatus.NOT_CONTAIN_TOKEN;
+
+@Service
+@RequiredArgsConstructor
+@Transactional
+public class TokenService {
+
+    private final JwtTokenProvider jwtTokenProvider;
+    private final TokenRepository tokenRepository;
+    private final MemberRepository memberRepository;
+
+    public AuthResponseDTO.TokenResponse reissueToken(HttpServletRequest request) {
+        String refreshToken = jwtTokenProvider.extractToken(request);
+        Token token = getToken(refreshToken);
+
+        Long memberId = validateRefreshToken(refreshToken);
+        String newAccessToken = jwtTokenProvider.createAccessToken(memberId);
+        String newRefreshToken = jwtTokenProvider.createRefreshToken(memberId);
+
+        // refreshToken 업데이트
+        token.changeToken(newRefreshToken);
+        return AuthConverter.toTokenRefreshResponse(newAccessToken, newRefreshToken);
+    }
+
+    public void deleteToken(HttpServletRequest request) {
+        String refreshToken = jwtTokenProvider.extractToken(request);
+        Token token = getToken(refreshToken);
+
+        tokenRepository.delete(token);
+    }
+
+    private Token getToken(String refreshToken) {
+        Optional<Token> token = tokenRepository.findByRefreshToken(refreshToken);
+        if (!token.isPresent()) {
+            throw new AuthException(NOT_CONTAIN_TOKEN);
+            // Logout 되어있는 상황
+        }
+        return token.get();
+    }
+
+
+    private Long validateRefreshToken(String refreshToken) {
+        jwtTokenProvider.isTokenValid(refreshToken);
+        Long memberId = jwtTokenProvider.getId(refreshToken);
+        return memberId;
+    }
+
+    public void deleteUser(HttpServletRequest request) {
+        String refreshToken = jwtTokenProvider.extractToken(request);
+        long memberId = validateRefreshToken(refreshToken);
+        memberRepository.deleteById(memberId);
+        deleteToken(request);
+    }
+}

--- a/src/main/java/com/stockpulse/stockpulseAPI/global/apiPayload/code/status/ErrorStatus.java
+++ b/src/main/java/com/stockpulse/stockpulseAPI/global/apiPayload/code/status/ErrorStatus.java
@@ -11,7 +11,32 @@ import org.springframework.http.HttpStatus;
 @AllArgsConstructor
 public enum ErrorStatus implements BaseErrorCode {
 
-    _INTERNAL_SERVER_ERROR(HttpStatus.INTERNAL_SERVER_ERROR, "COMMON500", "서버 에러, 관리자에게 문의 바랍니다.");
+    _INTERNAL_SERVER_ERROR(HttpStatus.INTERNAL_SERVER_ERROR, "COMMON500", "서버 에러, 관리자에게 문의 바랍니다."),
+    _BAD_REQUEST(HttpStatus.BAD_REQUEST, "COMMON400", "잘못된 요청입니다."),
+    _UNAUTHORIZED(HttpStatus.UNAUTHORIZED, "COMMON401", "인증이 필요합니다."),
+    _FORBIDDEN(HttpStatus.FORBIDDEN, "COMMON403", "금지된 요청입니다."),
+
+    // Member
+    MEMBER_NOT_FOUND(HttpStatus.BAD_REQUEST, "MEMBER4001", "사용자가 없습니다."),
+    NICKNAME_NOT_EXIST(HttpStatus.BAD_REQUEST, "MEMBER4002", "닉네임은 필수 입니다."),
+
+    // Auth 관련
+    AUTH_EXTRACT_ERROR_TEST(HttpStatus.UNAUTHORIZED, "AUTH_000TSET", "토큰 추출에 실패했습니다TEST."),
+
+    AUTH_EXTRACT_ERROR(HttpStatus.UNAUTHORIZED, "AUTH_000", "토큰 추출에 실패했습니다."),
+    AUTH_EXPIRED_TOKEN(HttpStatus.UNAUTHORIZED, "AUTH_001", "토큰이 만료되었습니다."),
+    AUTH_INVALID_TOKEN(HttpStatus.UNAUTHORIZED, "AUTH_002", "토큰이 유효하지 않습니다."),
+    INVALID_LOGIN_REQUEST(HttpStatus.UNAUTHORIZED, "AUTH_003", "올바른 아이디나 패스워드가 아닙니다."),
+    NOT_EQUAL_TOKEN(HttpStatus.UNAUTHORIZED, "AUTH_004", "리프레시 토큰이 다릅니다."),
+    NOT_CONTAIN_TOKEN(HttpStatus.UNAUTHORIZED, "AUTH_005", "해당하는 토큰이 저장되어있지 않습니다."),
+    INVALID_PASSWORD(HttpStatus.UNAUTHORIZED, "AUTH_006", "비밀번호가 일치하지 않습니다."),
+    INVALID_REQUEST_INFO_KAKAO(HttpStatus.UNAUTHORIZED, "AUTH_007", "카카오 정보 불러오기에 실패하였습니다."),
+    AUTH_INVALID_CODE(HttpStatus.UNAUTHORIZED, "", "코드가 유효하지 않습니다."),
+
+    // User 관련
+    USER_NOT_FOUND(HttpStatus.NOT_FOUND, "USER_001", "존재하지 않는 사용자입니다."),
+    USER_EXISTS(HttpStatus.BAD_REQUEST, "USER_002", "이미 존재하는 아이디입니다."),
+    USER_DELETE_FAILED(HttpStatus.NOT_FOUND, "USER_003", "회원 탈퇴에 실패했습니다.");
 
     private final HttpStatus httpStatus;
     private final String code;

--- a/src/main/java/com/stockpulse/stockpulseAPI/global/apiPayload/code/status/SuccessStatus.java
+++ b/src/main/java/com/stockpulse/stockpulseAPI/global/apiPayload/code/status/SuccessStatus.java
@@ -11,7 +11,13 @@ import org.springframework.http.HttpStatus;
 @AllArgsConstructor
 public enum SuccessStatus implements BaseCode {
 
-    _OK(HttpStatus.OK, "COMMON200", "성공입니다.");
+    _OK(HttpStatus.OK, "COMMON200", "성공입니다."),
+
+    // 회원 가능 관련
+    USER_LOGIN_OK(HttpStatus.OK, "AUTH2001", "회원 로그인이 완료되었습니다."),
+    USER_LOGOUT_OK(HttpStatus.OK, "AUTH2002", "회원 로그아웃이 완료되었습니다."),
+    USER_DELETE_OK(HttpStatus.OK, "AUTH2003", "회원 탈퇴가 완료되었습니다."),
+    USER_REFRESH_OK(HttpStatus.OK, "AUTH2004", "토큰 재발급이 완료되었습니다.");
 
     private final HttpStatus httpStatus;
     private final String code;

--- a/src/main/java/com/stockpulse/stockpulseAPI/global/configuration/SecurityConfig.java
+++ b/src/main/java/com/stockpulse/stockpulseAPI/global/configuration/SecurityConfig.java
@@ -1,0 +1,115 @@
+package com.stockpulse.stockpulseAPI.global.configuration;
+
+import com.stockpulse.stockpulseAPI.global.security.filter.JwtRequestFilter;
+import jakarta.servlet.http.HttpServletResponse;
+import lombok.RequiredArgsConstructor;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.security.config.annotation.web.builders.HttpSecurity;
+import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
+import org.springframework.security.config.annotation.web.configurers.AbstractHttpConfigurer;
+import org.springframework.security.config.annotation.web.configurers.HeadersConfigurer;
+import org.springframework.security.config.http.SessionCreationPolicy;
+import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
+import org.springframework.security.web.SecurityFilterChain;
+import org.springframework.security.web.access.AccessDeniedHandler;
+import org.springframework.security.web.authentication.UsernamePasswordAuthenticationFilter;
+import org.springframework.web.cors.CorsConfiguration;
+import org.springframework.web.cors.CorsConfigurationSource;
+import org.springframework.web.cors.UrlBasedCorsConfigurationSource;
+
+import java.util.List;
+
+@Configuration
+@EnableWebSecurity
+@RequiredArgsConstructor
+public class SecurityConfig {
+
+    private static final String ALLOW_AUTH_URL = "/api/auth/**";
+    private static final String ALLOW_OPEN_API = "/api/open-api/**";
+
+    private static final String[] SECURITY_ALLOW_ARRAY = { //인증 없이 접근 가능한 엔드 포인트
+            ALLOW_AUTH_URL,
+            ALLOW_OPEN_API,
+            "/error",
+            "/swagger-ui/**",
+            "/swagger-resources/**",
+            "/v3/api-docs/**",
+            "/webjars/**",
+            "/swagger-ui.html",
+            "/login",
+            "/refresh",
+            "/actuator/prometheus",
+            "/ws/**",
+            "/topic/**",
+            "/api/post/**",
+            "/api/recommend/**",
+            "/favicon.ico"
+    };
+
+    private final JwtRequestFilter jwtRequestFilter;
+
+    @Bean
+    public BCryptPasswordEncoder passwordEncoder() {
+        return new BCryptPasswordEncoder();
+    }
+
+    @Bean
+    public SecurityFilterChain filterChain(HttpSecurity http) throws Exception {
+        http.csrf(AbstractHttpConfigurer::disable);
+        http.cors(cors -> cors.configurationSource(corsConfigurationSource()));
+        http.formLogin(AbstractHttpConfigurer::disable);
+        http.httpBasic(AbstractHttpConfigurer::disable);
+        http.headers(headers -> headers.frameOptions(HeadersConfigurer.FrameOptionsConfig::sameOrigin));
+        http.sessionManagement(session -> session.sessionCreationPolicy(SessionCreationPolicy.STATELESS));
+        configureAuthorization(http);
+        configureExceptionHandling(http);
+        http.addFilterBefore(jwtRequestFilter, UsernamePasswordAuthenticationFilter.class);
+
+        return http.build();
+    }
+
+    @Bean
+    public CorsConfigurationSource corsConfigurationSource() {
+        CorsConfiguration configuration = new CorsConfiguration();
+        configuration.setAllowedOrigins(List.of("*"));
+        configuration.setAllowedMethods(List.of("GET", "POST", "PUT", "DELETE", "OPTIONS"));
+        configuration.setAllowedHeaders(List.of("*"));
+        configuration.setAllowCredentials(true);
+
+        UrlBasedCorsConfigurationSource source = new UrlBasedCorsConfigurationSource();
+        source.registerCorsConfiguration("/**", configuration);
+        return source;
+    }
+
+    private void configureAuthorization(HttpSecurity http) throws Exception {
+        http.authorizeHttpRequests(auth -> auth
+                .requestMatchers(SECURITY_ALLOW_ARRAY).permitAll()
+                .anyRequest().hasAnyAuthority("ROLE_USER")
+        );
+    }
+
+    private void configureExceptionHandling(HttpSecurity http) throws Exception {
+        http.exceptionHandling(exceptions -> exceptions
+                .accessDeniedHandler(accessDeniedHandler())
+                .authenticationEntryPoint((request, response, authException) -> {
+                    response.setStatus(HttpServletResponse.SC_UNAUTHORIZED);
+                    response.setContentType("application/json");
+                    response.setCharacterEncoding("UTF-8");
+                    response.getWriter().write("{ \"error\": \"Unauthorized\", \"message\": \"인증이 필요합니다.\" }");
+                })
+        );
+    }
+
+    @Bean
+    public AccessDeniedHandler accessDeniedHandler() {
+        return (request, response, accessDeniedException) -> {
+            response.setStatus(HttpServletResponse.SC_FORBIDDEN);
+            response.setContentType("application/json");
+            response.setCharacterEncoding("UTF-8");
+            response.getWriter().write("{ \"error\": \"Access Denied\", \"message\": \"권한이 없습니다.\", \"path\": \""
+                    + request.getRequestURI() + "\" }");
+        };
+    }
+
+}

--- a/src/main/java/com/stockpulse/stockpulseAPI/global/configuration/WebConfig.java
+++ b/src/main/java/com/stockpulse/stockpulseAPI/global/configuration/WebConfig.java
@@ -1,0 +1,24 @@
+package com.stockpulse.stockpulseAPI.global.configuration;
+
+import com.stockpulse.stockpulseAPI.global.security.handler.resolver.AuthUserArgumentResolver;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.web.method.support.HandlerMethodArgumentResolver;
+import org.springframework.web.servlet.config.annotation.WebMvcConfigurer;
+
+import java.util.List;
+
+@Configuration
+public class WebConfig implements WebMvcConfigurer {
+
+    private final AuthUserArgumentResolver authUserArgumentResolver;
+
+    public WebConfig(AuthUserArgumentResolver authUserArgumentResolver) {
+        this.authUserArgumentResolver = authUserArgumentResolver;
+    }
+
+    @Override
+    public void addArgumentResolvers(List<HandlerMethodArgumentResolver> resolvers) {
+        // Argument Resolver 등록
+        resolvers.add(authUserArgumentResolver);
+    }
+}

--- a/src/main/java/com/stockpulse/stockpulseAPI/global/converter/MultipartJackson2HttpMessageConverter.java
+++ b/src/main/java/com/stockpulse/stockpulseAPI/global/converter/MultipartJackson2HttpMessageConverter.java
@@ -1,0 +1,31 @@
+package com.stockpulse.stockpulseAPI.global.converter;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.springframework.http.MediaType;
+import org.springframework.http.converter.json.AbstractJackson2HttpMessageConverter;
+import org.springframework.stereotype.Component;
+
+import java.lang.reflect.Type;
+
+@Component
+public class MultipartJackson2HttpMessageConverter extends AbstractJackson2HttpMessageConverter {
+
+    public MultipartJackson2HttpMessageConverter(ObjectMapper objectMapper) {
+        super(objectMapper, MediaType.APPLICATION_OCTET_STREAM);
+    }
+
+    @Override
+    public boolean canWrite(Class<?> clazz, MediaType mediaType) {
+        return false;
+    }
+
+    @Override
+    public boolean canWrite(Type type, Class<?> clazz, MediaType mediaType) {
+        return false;
+    }
+
+    @Override
+    protected boolean canWrite(MediaType mediaType) {
+        return false;
+    }
+}

--- a/src/main/java/com/stockpulse/stockpulseAPI/global/security/authDTO/AuthRequestDTO.java
+++ b/src/main/java/com/stockpulse/stockpulseAPI/global/security/authDTO/AuthRequestDTO.java
@@ -1,0 +1,12 @@
+package com.stockpulse.stockpulseAPI.global.security.authDTO;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import lombok.Getter;
+
+public class AuthRequestDTO {
+    @Getter
+    public static class RefreshTokenDTO {
+        @JsonProperty("refresh_token")
+        String refreshToken;
+    }
+}

--- a/src/main/java/com/stockpulse/stockpulseAPI/global/security/authDTO/AuthResponseDTO.java
+++ b/src/main/java/com/stockpulse/stockpulseAPI/global/security/authDTO/AuthResponseDTO.java
@@ -1,0 +1,25 @@
+package com.stockpulse.stockpulseAPI.global.security.authDTO;
+
+import lombok.*;
+
+public class AuthResponseDTO {
+    @Getter
+    @Builder
+    @AllArgsConstructor(access = AccessLevel.PROTECTED)
+    @NoArgsConstructor(access = AccessLevel.PROTECTED)
+    public static class OAuthResponse {
+        Long memberId;
+        String accessToken;
+        String refreshToken;
+    }
+
+    @Getter
+    @Builder
+    @AllArgsConstructor(access = AccessLevel.PROTECTED)
+    @NoArgsConstructor(access = AccessLevel.PROTECTED)
+    public static class TokenResponse {
+        String accessToken;
+        String refreshToken;
+    }
+
+}

--- a/src/main/java/com/stockpulse/stockpulseAPI/global/security/authDTO/KakaoProfile.java
+++ b/src/main/java/com/stockpulse/stockpulseAPI/global/security/authDTO/KakaoProfile.java
@@ -1,0 +1,27 @@
+package com.stockpulse.stockpulseAPI.global.security.authDTO;
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import lombok.Getter;
+
+@Getter
+@JsonIgnoreProperties(ignoreUnknown = true)
+public class KakaoProfile {
+    @JsonProperty("kakao_account")
+    private KakaoAccount kakaoAccount;
+
+    @JsonProperty("properties")
+    private KakaoNickname kakaoNickname;
+
+    @Getter
+    @JsonIgnoreProperties(ignoreUnknown = true)
+    public static class KakaoAccount {
+        private String email;
+    }
+
+    @Getter
+    @JsonIgnoreProperties(ignoreUnknown = true)
+    public static class KakaoNickname {
+        private String nickname;
+    }
+}

--- a/src/main/java/com/stockpulse/stockpulseAPI/global/security/authDTO/OAuthToken.java
+++ b/src/main/java/com/stockpulse/stockpulseAPI/global/security/authDTO/OAuthToken.java
@@ -1,0 +1,14 @@
+package com.stockpulse.stockpulseAPI.global.security.authDTO;
+
+import lombok.Data;
+
+@Data
+public class OAuthToken {
+    private String access_token;
+    private String token_type;
+    private String refresh_token;
+    private String id_token;
+    private int expires_in;
+    private String scope;
+    private int refresh_token_expires_in;
+}

--- a/src/main/java/com/stockpulse/stockpulseAPI/global/security/controller/AuthController.java
+++ b/src/main/java/com/stockpulse/stockpulseAPI/global/security/controller/AuthController.java
@@ -44,4 +44,11 @@ public class AuthController {
         tokenService.deleteUser(request);
         return ApiResponse.of(SuccessStatus.USER_DELETE_OK,null);
     }
+
+    @Operation(summary = "사용자 ID 주입 테스트", description = "@AuthUser을 사용한 현사용자 ID 자동 주입 예시입니다.")
+    @GetMapping("test")
+    public ApiResponse<String> loginTest(@AuthUser Long userId){
+        String result = "userID : " + userId;
+        return ApiResponse.onSuccess(result);
+    }
 }

--- a/src/main/java/com/stockpulse/stockpulseAPI/global/security/controller/AuthController.java
+++ b/src/main/java/com/stockpulse/stockpulseAPI/global/security/controller/AuthController.java
@@ -1,0 +1,47 @@
+package com.stockpulse.stockpulseAPI.global.security.controller;
+
+import com.stockpulse.stockpulseAPI.domain.token.service.TokenService;
+import com.stockpulse.stockpulseAPI.global.apiPayload.ApiResponse;
+import com.stockpulse.stockpulseAPI.global.apiPayload.code.status.SuccessStatus;
+import com.stockpulse.stockpulseAPI.global.security.authDTO.AuthResponseDTO;
+import com.stockpulse.stockpulseAPI.global.security.handler.annotation.AuthUser;
+import io.swagger.v3.oas.annotations.Operation;
+import jakarta.servlet.http.HttpServletRequest;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+import org.springframework.web.bind.annotation.*;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/api/auth")
+public class AuthController {
+
+    private final AuthService authService;
+    private final TokenService tokenService;
+
+    @ResponseStatus(code = HttpStatus.OK)
+    @Operation(
+            summary = "카카오 로그인 API (개발용, 인가 코드 → JWT 발급)",
+            description = "클라이언트 연동 전 백엔드 개발을 위한 임시 카카오 로그인 API 입니다. 인가코드를 입력하시면 JWT 토큰이 발급됩니다.")
+    @GetMapping("/login/kakao/test")
+    public ApiResponse<AuthResponseDTO.OAuthResponse> kakaoLoginTest(@RequestParam("code") String code) {
+        return ApiResponse.of(SuccessStatus.USER_LOGIN_OK, authService.kakaoLoginTest(code));
+    }
+
+    @ResponseStatus(code = HttpStatus.OK)
+    @Operation(
+            summary = "카카오 로그인 API (Access Token → JWT 발급)",
+            description = "카카오 Access Token을 전달하면 JWT 토큰이 발급됩니다. 프론트엔드 연동 시 로그인 및 회원가입은 해당 로직으로 처리됩니다.")
+    @GetMapping("/login/kakao")
+    public ApiResponse<AuthResponseDTO.OAuthResponse> kakaoLogin(@RequestParam("access_token") String token) {
+        return ApiResponse.of(SuccessStatus.USER_LOGIN_OK, authService.kakaoLogin(token));
+    }
+
+    @ResponseStatus(code = HttpStatus.OK)
+    @Operation(summary = "회원 탈퇴 API", description = "회원 탈퇴 API 입니다")
+    @DeleteMapping("/deactivate")
+    public ApiResponse<Void> AccountDeactivation(HttpServletRequest request) {
+        tokenService.deleteUser(request);
+        return ApiResponse.of(SuccessStatus.USER_DELETE_OK,null);
+    }
+}

--- a/src/main/java/com/stockpulse/stockpulseAPI/global/security/controller/AuthService.java
+++ b/src/main/java/com/stockpulse/stockpulseAPI/global/security/controller/AuthService.java
@@ -1,0 +1,116 @@
+package com.stockpulse.stockpulseAPI.global.security.controller;
+
+import com.stockpulse.stockpulseAPI.domain.member.entity.Member;
+import com.stockpulse.stockpulseAPI.domain.member.repository.MemberRepository;
+import com.stockpulse.stockpulseAPI.domain.token.domain.Token;
+import com.stockpulse.stockpulseAPI.domain.token.repository.TokenRepository;
+import com.stockpulse.stockpulseAPI.global.apiPayload.code.status.ErrorStatus;
+import com.stockpulse.stockpulseAPI.global.security.authDTO.AuthResponseDTO;
+import com.stockpulse.stockpulseAPI.global.security.authDTO.KakaoProfile;
+import com.stockpulse.stockpulseAPI.global.security.authDTO.OAuthToken;
+import com.stockpulse.stockpulseAPI.global.security.converter.AuthConverter;
+import com.stockpulse.stockpulseAPI.global.security.exception.AuthException;
+import com.stockpulse.stockpulseAPI.global.security.provider.JwtTokenProvider;
+import com.stockpulse.stockpulseAPI.global.security.provider.KakaoAuthProvider;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.Optional;
+
+@Service
+@RequiredArgsConstructor
+public class AuthService {
+
+    private final TokenRepository tokenRepository;
+    private final MemberRepository memberRepository;
+    private final KakaoAuthProvider kakaoAuthProvider;
+    private final JwtTokenProvider jwtTokenProvider;
+
+    //카카오 로그인 test
+    @Transactional
+    public AuthResponseDTO.OAuthResponse kakaoLoginTest(String code) {
+        OAuthToken oAuthToken = getKakaoOauthToken(code);
+
+        KakaoProfile kakaoProfile;
+        try {
+            kakaoProfile =
+                    kakaoAuthProvider.requestKakaoProfile(oAuthToken.getAccess_token());
+        } catch (Exception e) {
+            throw new AuthException(ErrorStatus.INVALID_REQUEST_INFO_KAKAO);
+        }
+
+        // 유저 정보 받기
+        Optional<Member> queryMember =
+                memberRepository.findByEmail(
+                        kakaoProfile.getKakaoAccount().getEmail());
+
+        // 가입자 혹은 비가입자 체크해서 로그인 처리
+        if (queryMember.isPresent()) {
+            Member member = queryMember.get();
+            return getOauthResponseForPresentUser(member, queryMember);
+        }
+
+        Member member = memberRepository.save(AuthConverter.kakaoToMember(kakaoProfile));
+        return getOauthResponseForNewUser(member);
+    }
+
+    //카카오 로그인
+    @Transactional
+    public AuthResponseDTO.OAuthResponse kakaoLogin(String token) {
+
+        KakaoProfile kakaoProfile;
+        try {
+            kakaoProfile =
+                    kakaoAuthProvider.requestKakaoProfile(token);
+        } catch (Exception e) {
+            throw new AuthException(ErrorStatus.INVALID_REQUEST_INFO_KAKAO);
+        }
+        // 유저 정보 받기
+        Optional<Member> queryMember =
+                memberRepository.findByEmail(
+                        kakaoProfile.getKakaoAccount().getEmail());
+        // 가입자 혹은 비가입자 체크해서 로그인 처리
+        if (queryMember.isPresent()) {
+            Member member = queryMember.get();
+            return getOauthResponseForPresentUser(member, queryMember);
+        }
+
+        Member member = memberRepository.save(AuthConverter.kakaoToMember(kakaoProfile));
+        return getOauthResponseForNewUser(member);
+    }
+
+    private AuthResponseDTO.OAuthResponse getOauthResponseForNewUser(Member member) {
+        String accessToken = jwtTokenProvider.createAccessToken(member.getId());
+        String refreshToken = jwtTokenProvider.createRefreshToken(member.getId());
+        saveNewMember(refreshToken, member);
+        return AuthConverter.toOAuthResponse(accessToken, refreshToken, member);
+    }
+
+    private AuthResponseDTO.OAuthResponse getOauthResponseForPresentUser(Member member, Optional<Member> queryMember) {
+        String accessToken = jwtTokenProvider.createAccessToken(member.getId());
+        String refreshToken = jwtTokenProvider.createRefreshToken(member.getId());
+        Optional<Token> savedRefreshToken = tokenRepository.findByMemberId(member.getId());
+        if (savedRefreshToken.isPresent()) {
+            savedRefreshToken.get().changeToken(refreshToken);
+        } else {
+            tokenRepository.save(new Token(refreshToken, member.getId()));
+        }
+        return AuthConverter.toOAuthResponse(accessToken, refreshToken, queryMember.get());
+    }
+
+    private void saveNewMember(String refreshToken, Member member) {
+        tokenRepository.save(new Token(refreshToken, member.getId()));
+        memberRepository.save(member);
+    }
+
+    private OAuthToken getKakaoOauthToken(String code) {
+        OAuthToken oAuthToken;
+        try {
+            oAuthToken = kakaoAuthProvider.requestToken(code);
+        } catch (Exception e) {
+            throw new AuthException(ErrorStatus.AUTH_INVALID_CODE);
+        }
+        return oAuthToken;
+    }
+}

--- a/src/main/java/com/stockpulse/stockpulseAPI/global/security/converter/AuthConverter.java
+++ b/src/main/java/com/stockpulse/stockpulseAPI/global/security/converter/AuthConverter.java
@@ -1,0 +1,32 @@
+package com.stockpulse.stockpulseAPI.global.security.converter;
+
+import com.stockpulse.stockpulseAPI.domain.member.entity.Member;
+import com.stockpulse.stockpulseAPI.global.security.authDTO.AuthResponseDTO;
+import com.stockpulse.stockpulseAPI.global.security.authDTO.KakaoProfile;
+
+public class AuthConverter {
+
+    public static Member kakaoToMember(KakaoProfile kakaoProfile) {
+        return Member.builder()
+                .nickname(kakaoProfile.getKakaoNickname().getNickname())
+                .email(kakaoProfile.getKakaoAccount().getEmail())
+                .build();
+    }
+
+    public static AuthResponseDTO.OAuthResponse toOAuthResponse(
+            String accessToken, String refreshToken, Member member) {
+        return AuthResponseDTO.OAuthResponse.builder()
+                .refreshToken(refreshToken)
+                .accessToken(accessToken)
+                .memberId(member.getId())
+                .build();
+    }
+
+    public static AuthResponseDTO.TokenResponse toTokenRefreshResponse(
+            String accessToken, String refreshToken) {
+        return AuthResponseDTO.TokenResponse.builder()
+                .accessToken(accessToken)
+                .refreshToken(refreshToken)
+                .build();
+    }
+}

--- a/src/main/java/com/stockpulse/stockpulseAPI/global/security/exception/AuthException.java
+++ b/src/main/java/com/stockpulse/stockpulseAPI/global/security/exception/AuthException.java
@@ -1,0 +1,11 @@
+package com.stockpulse.stockpulseAPI.global.security.exception;
+
+
+import com.stockpulse.stockpulseAPI.global.apiPayload.code.BaseErrorCode;
+import com.stockpulse.stockpulseAPI.global.apiPayload.exception.GeneralException;
+
+public class AuthException extends GeneralException {
+    public AuthException(BaseErrorCode code) {
+        super(code);
+    }
+}

--- a/src/main/java/com/stockpulse/stockpulseAPI/global/security/filter/JwtRequestFilter.java
+++ b/src/main/java/com/stockpulse/stockpulseAPI/global/security/filter/JwtRequestFilter.java
@@ -1,0 +1,98 @@
+package com.stockpulse.stockpulseAPI.global.security.filter;
+
+import com.stockpulse.stockpulseAPI.global.apiPayload.code.status.ErrorStatus;
+import com.stockpulse.stockpulseAPI.global.security.exception.AuthException;
+import com.stockpulse.stockpulseAPI.global.security.principal.PrincipalDetailsService;
+import com.stockpulse.stockpulseAPI.global.security.provider.JwtTokenProvider;
+import jakarta.servlet.FilterChain;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import lombok.RequiredArgsConstructor;
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.security.core.userdetails.UserDetails;
+import org.springframework.stereotype.Component;
+import org.springframework.web.filter.OncePerRequestFilter;
+
+import java.io.IOException;
+
+@Component
+@RequiredArgsConstructor
+public class JwtRequestFilter extends OncePerRequestFilter {
+
+    private final JwtTokenProvider jwtTokenProvider;
+    private final PrincipalDetailsService principalDetailsService;
+
+    @Override
+    protected void doFilterInternal(
+            HttpServletRequest request, HttpServletResponse response, FilterChain filterChain)
+            throws IOException, ServletException {
+
+        String path = request.getRequestURI();
+
+        // 1) 만약 Swagger, 로그인 등 "인증이 필요 없는 경로"이면 → 토큰 검증 스킵
+        if (isPermitAllPath(path)) {
+            filterChain.doFilter(request, response);
+            return;
+        }
+
+        try {
+            String token = jwtTokenProvider.extractToken(request);
+
+            if (jwtTokenProvider.isTokenValid(token)) {
+                Long userId = jwtTokenProvider.getId(token);
+                UserDetails userDetails =
+                        principalDetailsService.loadUserByUsername(userId.toString());
+
+                if (userDetails != null) {
+                    UsernamePasswordAuthenticationToken usernamePasswordAuthenticationToken =
+                            new UsernamePasswordAuthenticationToken(
+                                    userDetails, "", userDetails.getAuthorities());
+                    SecurityContextHolder.getContext()
+                            .setAuthentication(usernamePasswordAuthenticationToken);
+                } else { //유저 없음
+                    throw new AuthException(ErrorStatus.USER_NOT_FOUND);
+                }
+            } else { //토큰이 유효하지 않음
+                throw new AuthException(ErrorStatus.AUTH_INVALID_TOKEN);
+            }
+
+            filterChain.doFilter(request, response);
+        } catch (AuthException ex) {
+            setJsonResponse(response, ex.getErrorReasonHttpStatus().getHttpStatus().value(),
+                    ex.getErrorReason().getCode(),
+                    ex.getErrorReason().getMessage());
+        } catch (Exception ex) {
+            setJsonResponse(response, HttpServletResponse.SC_INTERNAL_SERVER_ERROR,
+                    "INTERNAL_SERVER_ERROR",
+                    "예기치 않은 오류가 발생했습니다.");
+        }
+    }
+
+    // JSON 응답 설정
+    private void setJsonResponse(HttpServletResponse response, int statusCode, String code, String message)
+            throws IOException {
+        response.setStatus(statusCode);
+        response.setContentType("application/json;charset=UTF-8");
+        String jsonResponse = String.format("{\"isSuccess\": false, \"code\": \"%s\", \"message\": \"%s\"}", code,
+                message);
+        response.getWriter().write(jsonResponse);
+    }
+
+    private boolean isPermitAllPath(String path) {
+        return path.startsWith("/swagger-ui")
+                || path.startsWith("/v3/api-docs")
+                || path.startsWith("/swagger-resources")
+                || path.startsWith("/webjars")
+                || path.equals("/swagger-ui.html")
+                || path.startsWith("/api/open-api")
+
+                || path.startsWith("/api/auth/login/")
+                || path.startsWith("/test")
+
+                // 필요하다면 다른 permitAll 경로들도 추가
+                // ...
+                ;
+    }
+}

--- a/src/main/java/com/stockpulse/stockpulseAPI/global/security/handler/annotation/AuthUser.java
+++ b/src/main/java/com/stockpulse/stockpulseAPI/global/security/handler/annotation/AuthUser.java
@@ -1,0 +1,14 @@
+package com.stockpulse.stockpulseAPI.global.security.handler.annotation;
+
+import io.swagger.v3.oas.annotations.Parameter;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+@Retention(RetentionPolicy.RUNTIME)
+@Target(ElementType.PARAMETER)
+@Parameter(hidden = true)
+public @interface AuthUser {
+}

--- a/src/main/java/com/stockpulse/stockpulseAPI/global/security/handler/resolver/AuthUserArgumentResolver.java
+++ b/src/main/java/com/stockpulse/stockpulseAPI/global/security/handler/resolver/AuthUserArgumentResolver.java
@@ -1,0 +1,53 @@
+package com.stockpulse.stockpulseAPI.global.security.handler.resolver;
+
+import com.stockpulse.stockpulseAPI.global.apiPayload.code.status.ErrorStatus;
+import com.stockpulse.stockpulseAPI.global.security.exception.AuthException;
+import com.stockpulse.stockpulseAPI.global.security.handler.annotation.AuthUser;
+import com.stockpulse.stockpulseAPI.global.security.principal.PrincipalDetails;
+import lombok.RequiredArgsConstructor;
+import org.springframework.core.MethodParameter;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.stereotype.Component;
+import org.springframework.web.bind.support.WebDataBinderFactory;
+import org.springframework.web.context.request.NativeWebRequest;
+import org.springframework.web.method.support.HandlerMethodArgumentResolver;
+import org.springframework.web.method.support.ModelAndViewContainer;
+
+@Component
+@RequiredArgsConstructor
+public class AuthUserArgumentResolver implements HandlerMethodArgumentResolver {
+
+    @Override
+    public boolean supportsParameter(MethodParameter parameter) {
+        return parameter.hasParameterAnnotation(AuthUser.class);
+    }
+
+    @Override
+    public Object resolveArgument(
+            MethodParameter parameter,
+            ModelAndViewContainer mavContainer,
+            NativeWebRequest webRequest,
+            WebDataBinderFactory binderFactory)
+            throws AuthException {
+        Authentication authentication = SecurityContextHolder.getContext().getAuthentication();
+
+        Object principal = null;
+        if (authentication != null) {
+
+            if (authentication.getName().equals("anonymousUser")) {
+                throw new AuthException(ErrorStatus._UNAUTHORIZED);
+            }
+            principal = authentication.getPrincipal();
+        }
+        if (principal == null || principal.getClass() == String.class) {
+            throw new AuthException(ErrorStatus.USER_NOT_FOUND);
+        }
+
+        if (principal instanceof PrincipalDetails) {
+            PrincipalDetails userDetails = (PrincipalDetails) principal;
+            return userDetails.getId();
+        }
+        throw new AuthException(ErrorStatus.USER_NOT_FOUND);
+    }
+}

--- a/src/main/java/com/stockpulse/stockpulseAPI/global/security/principal/PrincipalDetails.java
+++ b/src/main/java/com/stockpulse/stockpulseAPI/global/security/principal/PrincipalDetails.java
@@ -1,0 +1,59 @@
+package com.stockpulse.stockpulseAPI.global.security.principal;
+
+import com.stockpulse.stockpulseAPI.domain.member.entity.Member;
+import lombok.RequiredArgsConstructor;
+import org.springframework.security.core.GrantedAuthority;
+import org.springframework.security.core.authority.SimpleGrantedAuthority;
+import org.springframework.security.core.userdetails.UserDetails;
+
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.List;
+import java.util.stream.Collectors;
+
+@RequiredArgsConstructor
+public class PrincipalDetails implements UserDetails {
+    private final Member member;
+
+    @Override
+    public Collection<? extends GrantedAuthority> getAuthorities() {
+        List<String> roles = new ArrayList<>();
+        roles.add("ROLE_USER");
+
+        return roles.stream().map(SimpleGrantedAuthority::new).collect(Collectors.toList());
+    }
+
+    @Override
+    public String getPassword() {
+        return null;
+    }
+
+    @Override
+    public String getUsername() {
+        return member.getNickname();
+    }
+
+    @Override
+    public boolean isAccountNonExpired() {
+        return true;
+    }
+
+    @Override
+    public boolean isAccountNonLocked() {
+        return true;
+    }
+
+    @Override
+    public boolean isCredentialsNonExpired() {
+        return true;
+    }
+
+    @Override
+    public boolean isEnabled() {
+        return true;
+    }
+
+    public Long getId() {
+        return member.getId();
+    }
+}

--- a/src/main/java/com/stockpulse/stockpulseAPI/global/security/principal/PrincipalDetailsService.java
+++ b/src/main/java/com/stockpulse/stockpulseAPI/global/security/principal/PrincipalDetailsService.java
@@ -1,0 +1,29 @@
+package com.stockpulse.stockpulseAPI.global.security.principal;
+
+import com.stockpulse.stockpulseAPI.domain.member.entity.Member;
+import com.stockpulse.stockpulseAPI.domain.member.repository.MemberRepository;
+import com.stockpulse.stockpulseAPI.global.apiPayload.code.status.ErrorStatus;
+import com.stockpulse.stockpulseAPI.global.security.exception.AuthException;
+import lombok.RequiredArgsConstructor;
+import org.springframework.security.core.userdetails.UserDetails;
+import org.springframework.security.core.userdetails.UserDetailsService;
+import org.springframework.security.core.userdetails.UsernameNotFoundException;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@Transactional(readOnly = true)
+@RequiredArgsConstructor
+public class PrincipalDetailsService implements UserDetailsService {
+    private final MemberRepository memberRepository;
+
+    @Override
+    public UserDetails loadUserByUsername(String userId) throws UsernameNotFoundException {
+        Member member =
+                memberRepository
+                        .findById(Long.parseLong(userId))
+                        .orElseThrow(() -> new AuthException(ErrorStatus.USER_NOT_FOUND));
+
+        return new PrincipalDetails(member);
+    }
+}

--- a/src/main/java/com/stockpulse/stockpulseAPI/global/security/provider/JwtTokenProvider.java
+++ b/src/main/java/com/stockpulse/stockpulseAPI/global/security/provider/JwtTokenProvider.java
@@ -1,0 +1,110 @@
+package com.stockpulse.stockpulseAPI.global.security.provider;
+
+import com.stockpulse.stockpulseAPI.global.apiPayload.code.status.ErrorStatus;
+import com.stockpulse.stockpulseAPI.global.security.exception.AuthException;
+import io.jsonwebtoken.*;
+import io.jsonwebtoken.security.Keys;
+import jakarta.servlet.http.HttpServletRequest;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.authority.SimpleGrantedAuthority;
+import org.springframework.security.core.userdetails.User;
+import org.springframework.stereotype.Component;
+
+import javax.crypto.SecretKey;
+import java.nio.charset.StandardCharsets;
+import java.time.ZonedDateTime;
+import java.util.Collections;
+import java.util.Date;
+
+import static com.stockpulse.stockpulseAPI.global.apiPayload.code.status.ErrorStatus.AUTH_EXTRACT_ERROR_TEST;
+
+
+@Component
+public class JwtTokenProvider {
+
+    private static final String HEADER_STRING = "Authorization";
+    private static final String HEADER_STRING_PREFIX = "Bearer ";
+
+    private final SecretKey secretKey;
+    private final long accessTokenValidityMilliseconds;
+    private final long refreshTokenValidityMilliseconds;
+
+    public JwtTokenProvider(
+            @Value("${jwt.secret}") final String secretKey,
+            @Value("${jwt.access-token-validity}") final long accessTokenValidityMilliseconds,
+            @Value("${jwt.refresh-token-validity}") final long refreshTokenValidityMilliseconds) {
+        this.secretKey = Keys.hmacShaKeyFor(secretKey.getBytes(StandardCharsets.UTF_8));
+        this.accessTokenValidityMilliseconds = accessTokenValidityMilliseconds;
+        this.refreshTokenValidityMilliseconds = refreshTokenValidityMilliseconds;
+    }
+
+    public String extractToken (final HttpServletRequest request) {
+        String authorizationHeader = request.getHeader(HEADER_STRING);
+
+        if (authorizationHeader != null && authorizationHeader.startsWith(HEADER_STRING_PREFIX)) {
+            return authorizationHeader.substring(7);
+        }
+        throw new AuthException(AUTH_EXTRACT_ERROR_TEST);
+    }
+
+    public String createAccessToken(Long memberId) {
+        return createToken(memberId, accessTokenValidityMilliseconds);
+    }
+
+    public String createRefreshToken(Long memberId) {
+        return createToken(memberId, refreshTokenValidityMilliseconds);
+    }
+
+    private String createToken(Long memberId, long validityMilliseconds) {
+        Claims claims = Jwts.claims();
+        claims.put("id", memberId);
+
+        ZonedDateTime now = ZonedDateTime.now();
+        ZonedDateTime tokenValidity = now.plusSeconds(validityMilliseconds / 1000);
+
+        return Jwts.builder()
+                .setClaims(claims)
+                .setIssuedAt(Date.from(now.toInstant()))
+                .setExpiration(Date.from(tokenValidity.toInstant()))
+                .signWith(secretKey, SignatureAlgorithm.HS256)
+                .compact();
+    }
+
+    public Long getId(String token) {
+        return getClaims(token).getBody().get("id", Long.class);
+    }
+
+    public boolean isTokenValid(String token) {
+        try {
+            Jws<Claims> claims = getClaims(token);
+            Date expiredDate = claims.getBody().getExpiration();
+            Date now = new Date();
+
+            return expiredDate.after(now);
+        } catch (ExpiredJwtException e) {
+            throw new AuthException(ErrorStatus.AUTH_EXPIRED_TOKEN);
+        } catch (SecurityException
+                 | MalformedJwtException
+                 | UnsupportedJwtException
+                 | IllegalArgumentException e) {
+            throw new AuthException(ErrorStatus.AUTH_INVALID_TOKEN);
+        }
+    }
+
+    private Jws<Claims> getClaims(String token) {
+        return Jwts.parserBuilder().setSigningKey(secretKey).build().parseClaimsJws(token);
+    }
+
+    public Authentication getAuthentication(String token) {
+        try {
+            Long memberId = getId(token); // Extract member ID from JWT
+            User principal = new User(memberId.toString(), "", Collections.singletonList(new SimpleGrantedAuthority("ROLE_USER")));
+            return new UsernamePasswordAuthenticationToken(principal, token, principal.getAuthorities());
+        } catch (Exception e) {
+            throw new AuthException(ErrorStatus.AUTH_INVALID_TOKEN);
+        }
+    }
+
+}

--- a/src/main/java/com/stockpulse/stockpulseAPI/global/security/provider/KakaoAuthProvider.java
+++ b/src/main/java/com/stockpulse/stockpulseAPI/global/security/provider/KakaoAuthProvider.java
@@ -1,0 +1,92 @@
+package com.stockpulse.stockpulseAPI.global.security.provider;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.stockpulse.stockpulseAPI.global.apiPayload.code.status.ErrorStatus;
+import com.stockpulse.stockpulseAPI.global.security.authDTO.KakaoProfile;
+import com.stockpulse.stockpulseAPI.global.security.authDTO.OAuthToken;
+import com.stockpulse.stockpulseAPI.global.security.exception.AuthException;
+import lombok.RequiredArgsConstructor;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.http.HttpEntity;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.HttpMethod;
+import org.springframework.http.ResponseEntity;
+import org.springframework.stereotype.Component;
+import org.springframework.util.LinkedMultiValueMap;
+import org.springframework.util.MultiValueMap;
+import org.springframework.web.client.RestTemplate;
+
+@Component
+@RequiredArgsConstructor
+public class KakaoAuthProvider {
+    @Value("${KAKAO_CLIENT_ID}")
+    private String client;
+
+    @Value("${KAKAO_REDIRECT_URI}")
+    private String redirect;
+
+    // code로 access 토큰 요청하기
+    public OAuthToken requestToken(String code) {
+        RestTemplate restTemplate = new RestTemplate();
+        HttpHeaders headers = new HttpHeaders();
+
+        headers.add("Content-type", "application/x-www-form-urlencoded;charset=utf-8");
+
+        MultiValueMap<String, String> params = new LinkedMultiValueMap<>();
+        params.add("grant_type", "authorization_code");
+        params.add("client_id", client);
+        params.add("redirect_uri", redirect);
+        params.add("code", code);
+
+        HttpEntity<MultiValueMap<String, String>> kakaoTokenRequest =
+                new HttpEntity<>(params, headers);
+
+        ResponseEntity<String> response =
+                restTemplate.exchange(
+                        "https://kauth.kakao.com/oauth/token",
+                        HttpMethod.POST,
+                        kakaoTokenRequest,
+                        String.class);
+
+        ObjectMapper objectMapper = new ObjectMapper();
+
+        OAuthToken oAuthToken = null;
+
+        try {
+            oAuthToken = objectMapper.readValue(response.getBody(), OAuthToken.class);
+        } catch (JsonProcessingException e) {
+            throw new AuthException(ErrorStatus.INVALID_REQUEST_INFO_KAKAO);
+        }
+
+        return oAuthToken;
+    }
+
+    // Token으로 정보 요청하기
+    public KakaoProfile requestKakaoProfile(String token) {
+        RestTemplate restTemplate = new RestTemplate();
+        HttpHeaders headers = new HttpHeaders();
+        headers.add("Content-type", "application/x-www-form-urlencoded;charset=utf-8");
+        headers.add("Authorization", "Bearer " + token);
+
+        HttpEntity<MultiValueMap<String, String>> kakaoProfileRequest = new HttpEntity<>(headers);
+
+        ResponseEntity<String> response =
+                restTemplate.exchange(
+                        "https://kapi.kakao.com/v2/user/me",
+                        HttpMethod.POST,
+                        kakaoProfileRequest,
+                        String.class);
+
+        ObjectMapper objectMapper = new ObjectMapper();
+        KakaoProfile kakaoProfile = null;
+        System.out.println(response.getBody());
+        try {
+            kakaoProfile = objectMapper.readValue(response.getBody(), KakaoProfile.class);
+        } catch (JsonProcessingException e) {
+            throw new AuthException(ErrorStatus.INVALID_REQUEST_INFO_KAKAO);
+        }
+        System.out.println(kakaoProfile.getKakaoAccount().getEmail());
+        return kakaoProfile;
+    }
+}

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -4,7 +4,6 @@ spring:
     username: ${DATABASE_USERNAME}
     password: ${DATABASE_PASSWORD}
     driver-class-name: com.mysql.cj.jdbc.Driver
-
   jpa:
     hibernate:
       ddl-auto: none
@@ -17,3 +16,23 @@ spring:
         use_sql_comments: true
         jdbc:
           batch_size: 1000
+  security:
+    oauth2:
+      client:
+        registration:
+          kakao:
+            client-authentication-method: client_secret_post
+            client-id: ${KAKAO_CLIENT_ID}
+            client-secret: ${KAKAO_CLIENT_SECRET}
+            redirect-uri: ${KAKAO_REDIRECT_URI}
+            authorization-grant-type: authorization_code
+            client-name: Kakao
+        provider:
+          kakao:
+            authorization-uri: https://kauth.kakao.com/oauth/authorize
+            token-uri: https://kauth.kakao.com/oauth/token
+            user-info-uri: https://kapi.kakao.com/v2/user/me
+jwt:
+  secret: ${JWT_SECRET_KEY}
+  access-token-validity: ${JWT_ACCESS_TOKEN_TIME}
+  refresh-token-validity: ${JWT_REFRESH_TOKEN_TIME}


### PR DESCRIPTION
## 📌 작업 내용

> ### 1. 카카오 소셜 로그인 API 구현
> - OAuth2 + JWT 기반 카카오 소셜 로그인 API가 추가되었습니다.
> - 로그인/회원가입은 하나의 엔드포인트로 처리됩니다.
> - 리프레시 토큰을 통한 액세스 토큰 재발급 API가 구현되었습니다.
> - 카카오 로그인 URL을 통해 사용자 인증 완료 후, redirect URI의 code를 컨트롤러로 넘겨주면 JWT access token이 발급됩니다. 자세한 내용은 팀 노션 페이지에 정리해두었습니다.
> - 개발 중에는 하단의 개발용 엔드포인트를 사용해주세요.

```
    @ResponseStatus(code = HttpStatus.OK)
    @Operation(
            summary = "카카오 로그인 API (개발용, 인가 코드 → JWT 발급)",
            description = "클라이언트 연동 전 백엔드 개발을 위한 임시 카카오 로그인 API 입니다. 인가코드를 입력하시면 JWT 토큰이 발급됩니다.")
    @GetMapping("/login/kakao/test")
    public ApiResponse<AuthResponseDTO.OAuthResponse> kakaoLoginTest(@RequestParam("code") String code) {
        return ApiResponse.of(SuccessStatus.USER_LOGIN_OK, authService.kakaoLoginTest(code));
    }
```

> ### 2. @AuthUser 어노테이션 추가 (A 대문자입니다.)
> - 현재 사용자 ID를 주입받을 수 있는 커스텀 어노테이션을 추가했습니다.
> - 사용 예시는 AuthController에 테스트 API로 구현해 두었으니 이용에 참고 부탁드립니다.

## ✨ 참고 사항

> API 명세 노션 페이지를 꼭 확인해주세요!

## 🧩 연관 이슈

> close #3 


<br>