### PR TITLE
✨[Feat] 뉴스 기반 종목 영향도 예측 파이프라인 데이터 수신 및 저장 (복수건 단위) API 구현

### DIFF
--- a/src/main/java/com/stockpulse/stockpulseAPI/domain/news/controller/NewsController.java
+++ b/src/main/java/com/stockpulse/stockpulseAPI/domain/news/controller/NewsController.java
@@ -19,20 +19,37 @@ public class NewsController {
     private final NewsQueryService newsQueryService;
 
     @Operation(
-            summary = "뉴스 기반 종목 영향 데이터 수신 및 저장",
+            summary = "뉴스 기반 종목 영향 데이터 수신 및 저장 - 단건",
             description = """
-    파이프라인으로부터 전달된 뉴스 데이터를 수신하고,
+    파이프라인으로부터 전달된 단일 뉴스 데이터를 수신하고,
     해당 뉴스의 고유 URL을 기준으로 중복 여부를 판별한 후,
     신규 뉴스 및 연관 종목에 대한 영향도 데이터를 저장합니다.
         
-    해당 API는 뉴스-종목 영향도 분석 파이프라인 산출 데이터 입력 지점으로 사용됩니다.
+    해당 API는 뉴스-종목 영향도 분석 파이프라인 단건 데이터 입력 지점으로 사용됩니다.
     """
     )
-    @PostMapping("/pipeline")
-    public ApiResponse<String> ingestNewsImpactAndNewsData(
+    @PostMapping("/pipeline/single")
+    public ApiResponse<String> ingestSingleNewsImpactData(
             @RequestBody NewsRequestDTO.NewsDataPostRequestDTO request) {
         newsCommandService.acceptDataFromPipeline(request);
-        return ApiResponse.onSuccess("data added successfully");
+        return ApiResponse.onSuccess("single news data added successfully");
+    }
+
+    @Operation(
+            summary = "뉴스 기반 종목 영향 데이터 수신 및 저장 -  복수건",
+            description = """
+    파이프라인으로부터 전달된 복수 뉴스 데이터를 일괄 수신하고,
+    각 뉴스의 고유 URL을 기준으로 중복 여부를 판별한 후,
+    신규 뉴스 및 연관 종목에 대한 영향도 데이터를 저장합니다.
+        
+    해당 API는 뉴스-종목 영향도 분석 파이프라인 배치 데이터 입력 지점으로 사용됩니다.
+    """
+    )
+    @PostMapping("/pipeline/batch")
+    public ApiResponse<String> ingestBatchNewsImpactData(
+            @RequestBody NewsRequestDTO.NewsDataBatchPostRequestDTO request) {
+        newsCommandService.acceptBatchDataFromPipeline(request);
+        return ApiResponse.onSuccess("batch news data added successfully");
     }
 
     @Operation(

--- a/src/main/java/com/stockpulse/stockpulseAPI/domain/news/dto/NewsRequestDTO.java
+++ b/src/main/java/com/stockpulse/stockpulseAPI/domain/news/dto/NewsRequestDTO.java
@@ -13,6 +13,15 @@ public class NewsRequestDTO {
     @Builder
     @NoArgsConstructor
     @AllArgsConstructor
+    public static class NewsDataBatchPostRequestDTO {
+        private List<NewsDataPostRequestDTO> newsDataList;
+    }
+
+    @Getter
+    @Setter
+    @Builder
+    @NoArgsConstructor
+    @AllArgsConstructor
     public static class NewsDataPostRequestDTO {
         private String newsTitle;
         private String newsUrl;
@@ -23,6 +32,7 @@ public class NewsRequestDTO {
         private LocalDateTime publishedDate;
         private List<NewsRelatedStocksDataDTO> relatedStocks;
     }
+
 
     @Getter
     @Setter

--- a/src/main/java/com/stockpulse/stockpulseAPI/domain/news/service/NewsCommandService.java
+++ b/src/main/java/com/stockpulse/stockpulseAPI/domain/news/service/NewsCommandService.java
@@ -34,23 +34,14 @@ public class NewsCommandService {
 
     @Transactional
     public void acceptDataFromPipeline(NewsRequestDTO.NewsDataPostRequestDTO request) {
-        News news = newsRepository.findByUrl(request.getNewsUrl())
-                .orElse(null);
-        if(news == null){
-            News newNews = News.builder()
-                    .title(request.getNewsTitle())
-                    .image(request.getNewsImage())
-                    .url(request.getNewsUrl())
-                    .press(request.getPress())
-                    .publishedDate(request.getPublishedDate())
-                    .content(request.getContent())
-                    .reason(request.getReason())
-                    .build();
-            newsRepository.save(newNews);
-            saveImpactFromNewsData(newNews, request.getRelatedStocks());
-            return;
+        processNewsData(request);
+    }
+
+    @Transactional
+    public void acceptBatchDataFromPipeline(NewsRequestDTO.NewsDataBatchPostRequestDTO request) {
+        for(NewsRequestDTO.NewsDataPostRequestDTO dto : request.getNewsDataList()){
+            processNewsData(dto);
         }
-        saveImpactFromNewsData(news, request.getRelatedStocks());
     }
 
     @Transactional
@@ -72,6 +63,32 @@ public class NewsCommandService {
             memberScrapNewsRepository.save(newsScrapNews);
             return new NewsResponseDTO.ScrapResultDTO(true);
         }
+    }
+
+    private void processNewsData(NewsRequestDTO.NewsDataPostRequestDTO request) {
+        Optional<News> existingNews = newsRepository.findByUrl(request.getNewsUrl());
+        
+        News news;
+        if(existingNews.isEmpty()){
+            news = createNewsFromRequest(request);
+            newsRepository.save(news);
+        } else {
+            news = existingNews.get();
+        }
+        
+        saveImpactFromNewsData(news, request.getRelatedStocks());
+    }
+
+    private News createNewsFromRequest(NewsRequestDTO.NewsDataPostRequestDTO request) {
+        return News.builder()
+                .title(request.getNewsTitle())
+                .image(request.getNewsImage())
+                .url(request.getNewsUrl())
+                .press(request.getPress())
+                .publishedDate(request.getPublishedDate())
+                .content(request.getContent())
+                .reason(request.getReason())
+                .build();
     }
 
     private void saveImpactFromNewsData(News news, List<NewsRequestDTO.NewsRelatedStocksDataDTO> request) {

--- a/src/main/java/com/stockpulse/stockpulseAPI/global/configuration/SecurityConfig.java
+++ b/src/main/java/com/stockpulse/stockpulseAPI/global/configuration/SecurityConfig.java
@@ -45,7 +45,7 @@ public class SecurityConfig {
             "/api/post/**",
             "/api/recommend/**",
             "/favicon.ico",
-            "/api/v1/news/pipeline"
+            "/api/v1/news/pipeline/**"
     };
 
     private final JwtRequestFilter jwtRequestFilter;

--- a/src/main/java/com/stockpulse/stockpulseAPI/global/security/filter/JwtRequestFilter.java
+++ b/src/main/java/com/stockpulse/stockpulseAPI/global/security/filter/JwtRequestFilter.java
@@ -89,7 +89,7 @@ public class JwtRequestFilter extends OncePerRequestFilter {
                 || path.startsWith("/api/open-api")
 
                 || path.startsWith("/api/auth/login/")
-                || path.startsWith("/api/v1/news/pipeline")
+                || path.startsWith("/api/v1/news/pipeline/")
                 || path.startsWith("/test")
 
                 // 필요하다면 다른 permitAll 경로들도 추가


### PR DESCRIPTION
## 📌 작업 내용

>  뉴스 기반 종목 영향도 예측 파이프라인 데이터 수신 및 저장 (복수건 단위) API 를 추가했습니다.

## ✨ 참고 사항

> 구현하는 과정에서 단건 저장 API의 기존 서비스 코드 메서드를 분리하여 가독성을 개선했습니다.
## 🧩 연관 이슈

> close #35 


<br>