### PR TITLE
🐛[Fix] 알림 관련 기능 수정

### DIFF
--- a/src/main/java/com/stockpulse/stockpulseAPI/domain/news/controller/NewsController.java
+++ b/src/main/java/com/stockpulse/stockpulseAPI/domain/news/controller/NewsController.java
@@ -93,7 +93,64 @@ public class NewsController {
     신규 뉴스 및 연관 종목에 대한 영향도 데이터를 저장합니다.
         
     해당 API는 뉴스-종목 영향도 분석 파이프라인 배치 데이터 입력 지점으로 사용됩니다.
-    """
+    """,
+            requestBody = @io.swagger.v3.oas.annotations.parameters.RequestBody(
+                    description = "NewsDataBatchPostRequestDTO",
+                    required = true,
+                    content = @Content(
+                        mediaType = "application/json",
+                        schema = @Schema(implementation = NewsRequestDTO.NewsDataBatchPostRequestDTO.class),
+                        examples = @ExampleObject(value =
+                        """
+                                { "newsDataList":
+                                 [
+                                 {
+                                   "newsTitle": "AI 반도체 호황에 국내 기술주 급등",
+                                   "newsUrl": "https://finance.example.com/news/20250810-ai-semiconductor-boom",
+                                   "newsImage": "https://cdn.example.com/images/ai-chip-2025.jpg",
+                                   "press": "한국경제",
+                                   "content": "전 세계적으로 AI 반도체 수요가 급증하면서 국내 주요 반도체·전자 기업들의 주가가 일제히 상승했다. 업계 전문가들은 메모리 반도체 가격 상승과 AI 서버 수요 확대로 2025년 하반기 실적 개선이 가속화될 것으로 전망하고 있다.",
+                                   "reason": "AI 데이터센터 투자 확대와 반도체 공급 부족 현상이 호재로 작용",
+                                   "publishedDate": "2025-08-10T08:40:31.720Z",
+                                   "relatedStocks": [
+                                     {
+                                       "stockName": "삼성전자",
+                                       "symbol": "005930",
+                                       "influenceScore": 3.2
+                                     },
+                                     {
+                                       "stockName": "SK하이닉스",
+                                       "symbol": "000660",
+                                       "influenceScore": 4.8
+                                     },
+                                     {
+                                       "stockName": "DB하이텍",
+                                       "symbol": "000990",
+                                       "influenceScore": 5.5
+                                     },
+                                     {
+                                       "stockName": "한미반도체",
+                                       "symbol": "042700",
+                                       "influenceScore": 7.1
+                                     },
+                                     {
+                                       "stockName": "네이버",
+                                       "symbol": "035420",
+                                       "influenceScore": 1.4
+                                     },
+                                     {
+                                       "stockName": "카카오",
+                                       "symbol": "035720",
+                                       "influenceScore": -0.8
+                                     }
+                                   ]
+                                 }
+                                 ]
+                                 }
+                        """
+                        )
+                    )
+            )
     )
     @PostMapping("/pipeline/batch")
     public ApiResponse<String> ingestBatchNewsImpactData(

--- a/src/main/java/com/stockpulse/stockpulseAPI/domain/news/service/NewsCommandService.java
+++ b/src/main/java/com/stockpulse/stockpulseAPI/domain/news/service/NewsCommandService.java
@@ -10,11 +10,13 @@ import com.stockpulse.stockpulseAPI.domain.news.entity.News;
 import com.stockpulse.stockpulseAPI.domain.news.repository.ImpactRepository;
 import com.stockpulse.stockpulseAPI.domain.news.repository.MemberScrapNewsRepository;
 import com.stockpulse.stockpulseAPI.domain.news.repository.NewsRepository;
+import com.stockpulse.stockpulseAPI.domain.notification.service.event.ImpactSavedEvent;
 import com.stockpulse.stockpulseAPI.domain.stock.repository.StockRepository;
 import com.stockpulse.stockpulseAPI.global.apiPayload.code.status.ErrorStatus;
 import com.stockpulse.stockpulseAPI.global.apiPayload.exception.handler.MemberHandler;
 import com.stockpulse.stockpulseAPI.global.apiPayload.exception.handler.NewsHandler;
 import lombok.RequiredArgsConstructor;
+import org.springframework.context.ApplicationEventPublisher;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -31,6 +33,7 @@ public class NewsCommandService {
     private final StockRepository stockRepository;
     private final MemberRepository memberRepository;
     private final MemberScrapNewsRepository memberScrapNewsRepository;
+    private final ApplicationEventPublisher eventPublisher;
 
     @Transactional
     public void acceptDataFromPipeline(NewsRequestDTO.NewsDataPostRequestDTO request) {
@@ -104,5 +107,7 @@ public class NewsCommandService {
             });
         }
         impactRepository.saveAll(impacts);
+
+        eventPublisher.publishEvent(new ImpactSavedEvent(impacts));
     }
 }

--- a/src/main/java/com/stockpulse/stockpulseAPI/domain/notification/controller/NotificationController.java
+++ b/src/main/java/com/stockpulse/stockpulseAPI/domain/notification/controller/NotificationController.java
@@ -4,11 +4,13 @@ import com.stockpulse.stockpulseAPI.domain.notification.dto.NotificationResponse
 import com.stockpulse.stockpulseAPI.domain.notification.service.NotificationService;
 import com.stockpulse.stockpulseAPI.global.apiPayload.ApiResponse;
 import com.stockpulse.stockpulseAPI.global.security.handler.annotation.AuthUser;
+import io.swagger.v3.oas.annotations.Operation;
 import jakarta.websocket.server.PathParam;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 
 import java.util.List;
@@ -20,10 +22,25 @@ public class NotificationController {
     private final NotificationService notificationService;
 
     @GetMapping("/history")
-    public ResponseEntity<ApiResponse<List<NotificationResponseDTO>>> getNotificationHistory(@AuthUser Long userId, @PathParam("type") String type) {
-        notificationService.getNotificationHistory(userId, type);
+    @Operation(
+            summary = "알림 이력 조회",
+            description = "알림 이력을 최근 순서대로 조회합니다. 관심 목록(interest), 보유 목록(owned)를 필터링하여 조회합니다." ,
+            parameters = {
+                    @io.swagger.v3.oas.annotations.Parameter(
+                            name = "type",
+                            description = "종목 필터링",
+                            required = true,
+                            schema = @io.swagger.v3.oas.annotations.media.Schema(type = "string", allowableValues = {"owned", "interest"}),
+                            example = "owned"
+                    )
+            }
+    )
+    public ResponseEntity<ApiResponse<NotificationResponseDTO>> getNotificationHistory(
+            @AuthUser Long userId,
+            @RequestParam("type") String type) {
+        NotificationResponseDTO response = notificationService.getNotificationHistory(userId, type);
 
         return ResponseEntity
-                .ok(ApiResponse.onSuccess(null));
+                .ok(ApiResponse.onSuccess(response));
     }
 }

--- a/src/main/java/com/stockpulse/stockpulseAPI/domain/notification/dto/NotificationResponseDTO.java
+++ b/src/main/java/com/stockpulse/stockpulseAPI/domain/notification/dto/NotificationResponseDTO.java
@@ -14,7 +14,7 @@ import java.util.List;
 @Getter
 @NoArgsConstructor
 public class NotificationResponseDTO {
-    private List<NotificationItemResponseDTO> notificationItems;
+    private List<NotificationItemResponseDTO> notificationItems = new ArrayList<>();
 
     @Getter
     @NoArgsConstructor

--- a/src/main/java/com/stockpulse/stockpulseAPI/domain/notification/fcm/FcmClient.java
+++ b/src/main/java/com/stockpulse/stockpulseAPI/domain/notification/fcm/FcmClient.java
@@ -11,6 +11,10 @@ import org.springframework.stereotype.Component;
 @Slf4j
 public class FcmClient {
     public void sendNotification(String token, String title, String body) {
+
+        if(token == "test")
+            return;
+
         Message message = Message.builder()
                 .setToken(token)
                 .setNotification(Notification.builder()

--- a/src/main/java/com/stockpulse/stockpulseAPI/domain/notification/service/NotificationService.java
+++ b/src/main/java/com/stockpulse/stockpulseAPI/domain/notification/service/NotificationService.java
@@ -14,9 +14,11 @@ import com.stockpulse.stockpulseAPI.domain.notification.fcm.FcmClient;
 import com.stockpulse.stockpulseAPI.domain.notification.repository.FcmTokenRepository;
 import com.stockpulse.stockpulseAPI.domain.notification.repository.NotificationRepository;
 import com.stockpulse.stockpulseAPI.domain.notification.repository.NotificationSettingRepository;
+import com.stockpulse.stockpulseAPI.domain.notification.service.event.ImpactSavedEvent;
 import com.stockpulse.stockpulseAPI.domain.stock.entity.Stock;
 import com.stockpulse.stockpulseAPI.domain.stock.repository.MemberFavoriteStockRepository;
 import lombok.RequiredArgsConstructor;
+import org.springframework.context.event.EventListener;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -65,8 +67,13 @@ public class NotificationService {
     }
 
 
+    @EventListener
     @Transactional
-    public void notification() {
+    public void handleImpactSavedEvent(ImpactSavedEvent event) {
+        notification(event.getImpacts());
+    }
+
+    public void notification(List<Impact> impacts) {
         /* TODO
          * 업데이트된 뉴스 영향도 가져오기
          * 영향도로 들어온 종목에 관심 있음을 등록한 사용자들을 찾는다.
@@ -77,14 +84,16 @@ public class NotificationService {
 
         // 1. 업데이트된 뉴스 영향도 조회
 //        List<NewsImpact> newsImpacts = newsImpactRepository.findRecentlyUpdated(LocalDateTime.now().minusMinutes(10));
-        List<Impact> impacts = impactRepository.findAll();
+//        List<Impact> impacts = impactRepository.findAll();
 
         for (Impact impact : impacts) {
             Stock stock = impact.getStock();
             Double impactScore = impact.getImpactRate().doubleValue(); // ex: +5.3, -2.1
 
             // 2. 해당 종목에 관심 있는 사용자 조회
-            List<Member> members = memberFavoriteStockRepository.findMembersByStock(stock).orElseThrow(() -> new IllegalArgumentException("종목에 관심한 사용자이 존재하지 않습니다."));
+            List<Member> members = memberFavoriteStockRepository
+                    .findMembersOwnStockOrMemberFavoriteStockByStockId(stock)
+                    .orElseThrow(() -> new IllegalArgumentException("종목에 관심한 사용가 존재하지 않습니다."));
             for (Member member : members) {
                 // 3. 사용자의 알림 세팅 조회
                 NotificationSetting setting = notificationSettingRepository.findByMember(member).orElseThrow(() -> new IllegalArgumentException("알림 세팅이 존재하지 않습니다."));

--- a/src/main/java/com/stockpulse/stockpulseAPI/domain/notification/service/event/ImpactSavedEvent.java
+++ b/src/main/java/com/stockpulse/stockpulseAPI/domain/notification/service/event/ImpactSavedEvent.java
@@ -1,0 +1,15 @@
+package com.stockpulse.stockpulseAPI.domain.notification.service.event;
+
+import com.stockpulse.stockpulseAPI.domain.news.entity.Impact;
+import lombok.Getter;
+
+import java.util.List;
+
+@Getter
+public class ImpactSavedEvent {
+    private final List<Impact> impacts;
+
+    public ImpactSavedEvent(List<Impact> impacts) {
+        this.impacts = impacts;
+    }
+}

--- a/src/main/java/com/stockpulse/stockpulseAPI/domain/notification/service/handler/NotificationEventHandler.java
+++ b/src/main/java/com/stockpulse/stockpulseAPI/domain/notification/service/handler/NotificationEventHandler.java
@@ -17,7 +17,7 @@ public class NotificationEventHandler {
     }
 
     @TransactionalEventListener(phase = TransactionPhase.AFTER_COMMIT)
-    @Transactional(propagation = Propagation.REQUIRES_NEW) // 🔥 이 메서드 자체를 새로운 트랜잭션으로 만듭니다.
+    @Transactional(propagation = Propagation.REQUIRES_NEW)
     public void handleMemberSavedEvent(MemberCreatedEvent event) {
         notificationService.initNotification(event.getMemberId());
     }

--- a/src/main/java/com/stockpulse/stockpulseAPI/domain/stock/repository/MemberFavoriteStockRepository.java
+++ b/src/main/java/com/stockpulse/stockpulseAPI/domain/stock/repository/MemberFavoriteStockRepository.java
@@ -20,4 +20,12 @@ public interface MemberFavoriteStockRepository extends JpaRepository<MemberFavor
     @Query("SELECT mfs FROM MemberFavoriteStock mfs WHERE mfs.member = :member AND mfs.stock = :stock")
     Optional<MemberFavoriteStock> findByMemberAndStock(@Param("member") Member member, @Param("stock") Stock stock);
 
+    @Query("""
+      SELECT m FROM Member m
+      JOIN MemberFavoriteStock mfs ON m.id = mfs.member.id
+      JOIN MemberOwnStock mos ON m.id = mos.member.id
+      WHERE mos.stock = :stock OR mfs.stock = :stock
+    """)
+    Optional<List<Member>> findMembersOwnStockOrMemberFavoriteStockByStockId(Stock stock);
+
 }


### PR DESCRIPTION
## 📌 작업 내용
신규 뉴스가 들어오면서 그와 관련된 주식을 보유하고 있는 사용자에게 알림을 보낼 때, 알림이 저장되지 않는 문제를 해결했습니다.
사용자가 수신한 알림 이력을 조회하는 API도 추가하였습니다.
기존의 관심 종목 사용자에게만 알림을 보내는 로직에서 보유 종목사용자에게도 알림을 가도록 수정하였습니다.

## ✨ 참고 사항



> 코드 리뷰 시 참고할 만한 사항이나 주의할 점을 작성해주세요.

## 🧩 연관 이슈
#18 

<br>