### PR TITLE
✨[Feat] 사용자 정보, 사용자 스크랩 뉴스 API 구현

### DIFF
--- a/src/main/java/com/stockpulse/stockpulseAPI/domain/member/controller/MemberController.java
+++ b/src/main/java/com/stockpulse/stockpulseAPI/domain/member/controller/MemberController.java
@@ -1,0 +1,77 @@
+package com.stockpulse.stockpulseAPI.domain.member.controller;
+
+import com.stockpulse.stockpulseAPI.domain.member.dto.MemberRequestDTO;
+import com.stockpulse.stockpulseAPI.domain.member.service.MemberService;
+import com.stockpulse.stockpulseAPI.domain.news.dto.NewsResponseDTO;
+import com.stockpulse.stockpulseAPI.global.apiPayload.ApiResponse;
+import com.stockpulse.stockpulseAPI.global.security.handler.annotation.AuthUser;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.ExampleObject;
+import io.swagger.v3.oas.annotations.media.Schema;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+
+import java.util.List;
+
+@RestController
+@RequestMapping("/api/v1/member")
+@RequiredArgsConstructor
+public class MemberController {
+
+    private final MemberService memberService;
+
+    @Operation(summary = "사용자 닉네임 조회")
+    @GetMapping("/nickname")
+    public ResponseEntity<ApiResponse<String>> getNickname(
+            @AuthUser Long userId
+    ) {
+        String response = memberService.getNickname(userId);
+        return ResponseEntity.ok(
+                ApiResponse.onSuccess(response)
+        );
+    }
+
+    @Operation(
+            summary = "사용자 닉네임 변경",
+            requestBody = @io.swagger.v3.oas.annotations.parameters.RequestBody(
+                description = "닉네임 정보",
+                required = true,
+                content = @Content(
+                        mediaType = "application/json",
+                        schema = @Schema(implementation = MemberRequestDTO.UpdateDTO.class)
+                        , examples = @ExampleObject(value = """
+                                {
+                                    "nickname": "주식똑똑이"
+                                }
+                                """
+                        )
+                )
+            )
+    )
+    @PatchMapping("/nickname")
+    public ResponseEntity<ApiResponse<String>> updateNickname(
+            @AuthUser Long userId,
+            @RequestBody MemberRequestDTO.UpdateDTO request
+    ) {
+        memberService.updateNickname(userId, request);
+        return ResponseEntity.ok(
+                ApiResponse.onSuccess("success")
+        );
+    }
+
+    @GetMapping("/news/scrap")
+    public ResponseEntity<ApiResponse<List<NewsResponseDTO.NewsOverviewDTO>>> getScrapNews(@AuthUser Long userId) {
+        List<NewsResponseDTO.NewsOverviewDTO> response = memberService.getScrapNews(userId);
+        return ResponseEntity.ok(
+                ApiResponse.onSuccess(response)
+        );
+    }
+}
+
+
+
+
+
+

--- a/src/main/java/com/stockpulse/stockpulseAPI/domain/member/controller/MemberController.java
+++ b/src/main/java/com/stockpulse/stockpulseAPI/domain/member/controller/MemberController.java
@@ -3,6 +3,7 @@ package com.stockpulse.stockpulseAPI.domain.member.controller;
 import com.stockpulse.stockpulseAPI.domain.member.dto.MemberRequestDTO;
 import com.stockpulse.stockpulseAPI.domain.member.service.MemberService;
 import com.stockpulse.stockpulseAPI.domain.news.dto.NewsResponseDTO;
+import com.stockpulse.stockpulseAPI.domain.post.dto.PostResponseDTO;
 import com.stockpulse.stockpulseAPI.global.apiPayload.ApiResponse;
 import com.stockpulse.stockpulseAPI.global.security.handler.annotation.AuthUser;
 import io.swagger.v3.oas.annotations.Operation;
@@ -36,18 +37,18 @@ public class MemberController {
     @Operation(
             summary = "사용자 닉네임 변경",
             requestBody = @io.swagger.v3.oas.annotations.parameters.RequestBody(
-                description = "닉네임 정보",
-                required = true,
-                content = @Content(
-                        mediaType = "application/json",
-                        schema = @Schema(implementation = MemberRequestDTO.UpdateDTO.class)
-                        , examples = @ExampleObject(value = """
-                                {
-                                    "nickname": "주식똑똑이"
-                                }
-                                """
-                        )
-                )
+                    description = "닉네임 정보",
+                    required = true,
+                    content = @Content(
+                            mediaType = "application/json",
+                            schema = @Schema(implementation = MemberRequestDTO.UpdateDTO.class)
+                            , examples = @ExampleObject(value = """
+                            {
+                                "nickname": "주식똑똑이"
+                            }
+                            """
+                    )
+                    )
             )
     )
     @PatchMapping("/nickname")
@@ -64,6 +65,23 @@ public class MemberController {
     @GetMapping("/news/scrap")
     public ResponseEntity<ApiResponse<List<NewsResponseDTO.NewsOverviewDTO>>> getScrapNews(@AuthUser Long userId) {
         List<NewsResponseDTO.NewsOverviewDTO> response = memberService.getScrapNews(userId);
+        return ResponseEntity.ok(
+                ApiResponse.onSuccess(response)
+        );
+    }
+
+    @GetMapping("/post/publish")
+    public ResponseEntity<ApiResponse<List<PostResponseDTO.SummaryDTO>>> getPublishedPosts(@AuthUser Long userId) {
+        List<PostResponseDTO.SummaryDTO> response = memberService.getPublishedPosts(userId);
+
+        return ResponseEntity.ok(
+                ApiResponse.onSuccess(response)
+        );
+    }
+
+    @GetMapping("/post/comment")
+    public ResponseEntity<ApiResponse<List<PostResponseDTO.SummaryDTO>>> getCommentedPosts(@AuthUser Long userId) {
+        List<PostResponseDTO.SummaryDTO> response = memberService.getCommentedPosts(userId);
         return ResponseEntity.ok(
                 ApiResponse.onSuccess(response)
         );

--- a/src/main/java/com/stockpulse/stockpulseAPI/domain/member/dto/MemberRequestDTO.java
+++ b/src/main/java/com/stockpulse/stockpulseAPI/domain/member/dto/MemberRequestDTO.java
@@ -1,0 +1,12 @@
+package com.stockpulse.stockpulseAPI.domain.member.dto;
+
+import lombok.Getter;
+
+public class MemberRequestDTO {
+
+    @Getter
+    public static class UpdateDTO {
+        public String nickname;
+    }
+
+}

--- a/src/main/java/com/stockpulse/stockpulseAPI/domain/member/entity/Member.java
+++ b/src/main/java/com/stockpulse/stockpulseAPI/domain/member/entity/Member.java
@@ -55,4 +55,8 @@ public class Member extends BaseEntity {
 
     @OneToMany(mappedBy = "member", cascade = CascadeType.ALL, orphanRemoval = true)
     private List<FcmToken> fcmTokenList = new ArrayList<>();
+
+    public void setNickname(String nickname) {
+        this.nickname = nickname;
+    }
 }

--- a/src/main/java/com/stockpulse/stockpulseAPI/domain/member/repository/MemberRepository.java
+++ b/src/main/java/com/stockpulse/stockpulseAPI/domain/member/repository/MemberRepository.java
@@ -1,10 +1,24 @@
 package com.stockpulse.stockpulseAPI.domain.member.repository;
 
 import com.stockpulse.stockpulseAPI.domain.member.entity.Member;
+import com.stockpulse.stockpulseAPI.domain.news.entity.MemberScrapNews;
+import com.stockpulse.stockpulseAPI.domain.news.entity.News;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 
+import java.util.List;
 import java.util.Optional;
 
 public interface MemberRepository extends JpaRepository<Member, Long> {
     Optional<Member> findByEmail(String email);
+
+    @Query("""
+            SELECT msn 
+            FROM MemberScrapNews msn
+            JOIN FETCH msn.news n           
+            WHERE msn.member.id = :userId  
+            ORDER BY msn.createdAt DESC            
+            """)
+    List<MemberScrapNews> findScrappedNewsWithNewsByUserId(@Param("userId") Long userId);
 }

--- a/src/main/java/com/stockpulse/stockpulseAPI/domain/member/repository/MemberRepository.java
+++ b/src/main/java/com/stockpulse/stockpulseAPI/domain/member/repository/MemberRepository.java
@@ -2,7 +2,8 @@ package com.stockpulse.stockpulseAPI.domain.member.repository;
 
 import com.stockpulse.stockpulseAPI.domain.member.entity.Member;
 import com.stockpulse.stockpulseAPI.domain.news.entity.MemberScrapNews;
-import com.stockpulse.stockpulseAPI.domain.news.entity.News;
+import com.stockpulse.stockpulseAPI.domain.post.entity.Comment;
+import com.stockpulse.stockpulseAPI.domain.post.entity.Post;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
@@ -19,6 +20,32 @@ public interface MemberRepository extends JpaRepository<Member, Long> {
             JOIN FETCH msn.news n           
             WHERE msn.member.id = :userId  
             ORDER BY msn.createdAt DESC            
-            """)
+    """)
     List<MemberScrapNews> findScrappedNewsWithNewsByUserId(@Param("userId") Long userId);
+
+    /**
+     * 특정 사용자가 작성한 모든 게시글을 연관 엔티티(Member, News, Stock)와 함께 조회합니다.
+     * JOIN FETCH를 사용하여 N+1 쿼리 문제를 방지합니다.
+     * @param userId 사용자의 ID
+     * @return 게시글 리스트
+     */
+    @Query("""
+           SELECT p
+           FROM Post p          
+           JOIN FETCH p.news n        
+           JOIN FETCH p.member m  
+           WHERE p.member.id = :userId
+           ORDER BY p.createdAt DESC
+    """)
+    List<Post> findPostsWithDetailByUserId(@Param("userId") Long userId);
+
+    @Query("""
+            SELECT c
+            FROM Comment c
+            JOIN FETCH c.post p
+            JOIN FETCH p.member m
+            WHERE c.member.id = :userId
+            ORDER BY c.createdAt DESC
+    """)
+    List<Comment> findPostsCommentedByUserId(Long userId);
 }

--- a/src/main/java/com/stockpulse/stockpulseAPI/domain/member/service/MemberService.java
+++ b/src/main/java/com/stockpulse/stockpulseAPI/domain/member/service/MemberService.java
@@ -1,0 +1,94 @@
+package com.stockpulse.stockpulseAPI.domain.member.service;
+
+import com.stockpulse.stockpulseAPI.domain.member.dto.MemberRequestDTO;
+import com.stockpulse.stockpulseAPI.domain.member.entity.Member;
+import com.stockpulse.stockpulseAPI.domain.member.repository.MemberRepository;
+import com.stockpulse.stockpulseAPI.domain.news.converter.NewsConverter;
+import com.stockpulse.stockpulseAPI.domain.news.dto.NewsResponseDTO;
+import com.stockpulse.stockpulseAPI.domain.news.entity.Impact;
+import com.stockpulse.stockpulseAPI.domain.news.entity.MemberScrapNews;
+import com.stockpulse.stockpulseAPI.domain.news.entity.News;
+import com.stockpulse.stockpulseAPI.domain.news.entity.Sentiment;
+import com.stockpulse.stockpulseAPI.domain.news.repository.ImpactRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.math.BigDecimal;
+import java.util.Collections;
+import java.util.List;
+import java.util.Map;
+import java.util.stream.Collectors;
+
+@Service
+@RequiredArgsConstructor
+public class MemberService {
+    private final MemberRepository memberRepository;
+    private final ImpactRepository impactRepository;
+
+    public String getNickname(Long userId) {
+        return memberRepository.findById(userId)
+                .orElseThrow(() -> new RuntimeException("Member not found")) // TODO : 커스텀 Exception 추가 필요
+                .getNickname();
+    }
+
+    @Transactional
+    public void updateNickname(Long userId, MemberRequestDTO.UpdateDTO request) {
+        Member member = memberRepository.findById(userId)
+                .orElseThrow(() -> new RuntimeException("Member not found"));// TODO : 커스텀 Exception 추가 필요
+
+        member.setNickname(request.getNickname());
+    }
+
+    public List<NewsResponseDTO.NewsOverviewDTO> getScrapNews(Long userId) {
+        List<MemberScrapNews> scrapNewsList = memberRepository.findScrappedNewsWithNewsByUserId(userId);
+
+        if(scrapNewsList.isEmpty()) {
+            return Collections.emptyList();
+        }
+
+        List<News> newsList = scrapNewsList.stream()
+                                .map(MemberScrapNews::getNews)
+
+                                .toList();
+
+        List<Impact> topImpacts = impactRepository.findTopImpactsForNewsList(newsList);
+
+        Map<News, Impact> topImpactsMap = topImpacts.stream()
+                .collect(Collectors.toMap(Impact::getNews, impact -> impact));
+
+        // 5. 스크랩 목록을 순회하며 Map을 이용해 최종 DTO를 만듭니다.
+        return scrapNewsList.stream()
+                .map(scrap -> {
+                    News news = scrap.getNews();
+                    Impact topImpact = topImpactsMap.get(news); // Map에서 해당 뉴스의 Top Impact를 찾음
+
+                    NewsResponseDTO.NewsOverviewStockDTO stockDTO
+                            = NewsConverter.toNewsOverviewStockDTO(
+                                topImpact.getStock(),
+                                topImpact,
+                                BigDecimal.valueOf(10.01),
+                                BigDecimal.valueOf(10.0)
+                            );
+
+                    Sentiment sentiment = parseSentiment(topImpact);
+                    return NewsConverter.toNewsOverviewDTO(news,
+                            true,
+                            sentiment,
+                            stockDTO
+                    );
+                })
+                .collect(Collectors.toList());
+    }
+
+    Sentiment parseSentiment(Impact impact) {
+        BigDecimal rate = impact.getImpactRate();
+        if (rate.compareTo(BigDecimal.ZERO) > 0) {
+            return Sentiment.POSITIVE;
+        } else if (rate.compareTo(BigDecimal.ZERO) < 0) {
+            return Sentiment.NEGATIVE;
+        }
+        return Sentiment.NEUTRAL;
+    }
+
+}

--- a/src/main/java/com/stockpulse/stockpulseAPI/domain/member/service/MemberService.java
+++ b/src/main/java/com/stockpulse/stockpulseAPI/domain/member/service/MemberService.java
@@ -10,6 +10,10 @@ import com.stockpulse.stockpulseAPI.domain.news.entity.MemberScrapNews;
 import com.stockpulse.stockpulseAPI.domain.news.entity.News;
 import com.stockpulse.stockpulseAPI.domain.news.entity.Sentiment;
 import com.stockpulse.stockpulseAPI.domain.news.repository.ImpactRepository;
+import com.stockpulse.stockpulseAPI.domain.news.repository.MemberScrapNewsRepository;
+import com.stockpulse.stockpulseAPI.domain.post.dto.PostResponseDTO;
+import com.stockpulse.stockpulseAPI.domain.post.entity.Comment;
+import com.stockpulse.stockpulseAPI.domain.post.entity.Post;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -25,6 +29,7 @@ import java.util.stream.Collectors;
 public class MemberService {
     private final MemberRepository memberRepository;
     private final ImpactRepository impactRepository;
+    private final MemberScrapNewsRepository memberScrapNewsRepository;
 
     public String getNickname(Long userId) {
         return memberRepository.findById(userId)
@@ -49,7 +54,7 @@ public class MemberService {
 
         List<News> newsList = scrapNewsList.stream()
                                 .map(MemberScrapNews::getNews)
-
+                                .distinct()
                                 .toList();
 
         List<Impact> topImpacts = impactRepository.findTopImpactsForNewsList(newsList);
@@ -78,6 +83,22 @@ public class MemberService {
                             stockDTO
                     );
                 })
+                .collect(Collectors.toList());
+    }
+
+    public List<PostResponseDTO.SummaryDTO> getPublishedPosts(Long userId) {
+        List<Post> posts = memberRepository.findPostsWithDetailByUserId(userId);
+
+        return posts.stream()
+                .map(PostResponseDTO.SummaryDTO::from)
+                .collect(Collectors.toList());
+    }
+
+    public List<PostResponseDTO.SummaryDTO> getCommentedPosts(Long userId) {
+        List<Comment> comments = memberRepository.findPostsCommentedByUserId(userId);
+        return comments.stream()
+                .map(Comment::getPost)
+                .map(PostResponseDTO.SummaryDTO::from)
                 .collect(Collectors.toList());
     }
 

--- a/src/main/java/com/stockpulse/stockpulseAPI/domain/news/repository/ImpactRepository.java
+++ b/src/main/java/com/stockpulse/stockpulseAPI/domain/news/repository/ImpactRepository.java
@@ -20,4 +20,16 @@ public interface ImpactRepository extends JpaRepository<Impact, Long> {
 
     @Query("SELECT i FROM Impact i JOIN FETCH i.news WHERE i.createdAt >= :todayStart ORDER BY ABS(i.impactRate) DESC")
     List<Impact> findTopByCreatedAtAfterOrderByImpactRateDescWithNews(@Param("todayStart") LocalDateTime todayStart, Pageable pageable);
+
+    @Query("""
+        SELECT i FROM Impact i
+        JOIN FETCH i.stock
+        WHERE i.news IN :newsList
+        AND i.impactRate = (
+            SELECT MAX(sub_i.impactRate)
+            FROM Impact sub_i
+            WHERE sub_i.news = i.news
+        )
+        """)
+    List<Impact> findTopImpactsForNewsList(@Param("newsList") List<News> newsList);
 }

--- a/src/main/java/com/stockpulse/stockpulseAPI/domain/post/controller/PostController.java
+++ b/src/main/java/com/stockpulse/stockpulseAPI/domain/post/controller/PostController.java
@@ -2,7 +2,7 @@ package com.stockpulse.stockpulseAPI.domain.post.controller;
 
 import com.stockpulse.stockpulseAPI.domain.news.dto.NewsResponseDTO;
 import com.stockpulse.stockpulseAPI.domain.post.dto.PostRequestDto;
-import com.stockpulse.stockpulseAPI.domain.post.dto.PostResponseDto;
+import com.stockpulse.stockpulseAPI.domain.post.dto.PostResponseDTO;
 import com.stockpulse.stockpulseAPI.domain.post.service.PostService;
 import com.stockpulse.stockpulseAPI.domain.stock.dto.StockResponseDTO;
 import com.stockpulse.stockpulseAPI.global.apiPayload.ApiResponse;
@@ -35,7 +35,7 @@ public class PostController {
     // TODO : 게시글 목록 조회
     @Operation(summary = "게시글 목록 조회", description = "게시글 목록을 조회합니다.")
     @GetMapping("/list")
-    public ResponseEntity<ApiResponse<List<PostResponseDto.PostSummaryDto>>> list(
+    public ResponseEntity<ApiResponse<List<PostResponseDTO.SummaryDTO>>> list(
             @Parameter(description = "페이지 번호(0부터 시작)", example = "0")
             @RequestParam("page") int page,
             @Parameter(description = "한 페이지 당 게시글 수", example = "10")
@@ -47,7 +47,7 @@ public class PostController {
                             @ExampleObject(name = "최신순", value = "latest", summary = "최신 작성 순")
                     })
             @RequestParam("sort") String sort) {
-        List<PostResponseDto.PostSummaryDto> posts = postService.getPostList(page, size, sort);
+        List<PostResponseDTO.SummaryDTO> posts = postService.getPostList(page, size, sort);
         return ResponseEntity
                 .ok()
                 .body(ApiResponse.onSuccess(posts));
@@ -92,7 +92,7 @@ public class PostController {
     @ApiResponses({
             @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "201", description = "댓글 성공적으로 등록됨",
                     content = @Content(mediaType = "application/json",
-                            schema = @Schema(implementation = PostResponseDto.CommentResponseDto.class),
+                            schema = @Schema(implementation = PostResponseDTO.CommentDTO.class),
                             examples = @ExampleObject(value = "{\"isSuccess\":true,\"code\":\"201\",\"message\":\"Created\",\"result\":{\"postId\":101}}"))),
     })
     @PostMapping("/write")
@@ -112,12 +112,12 @@ public class PostController {
     // 댓글 등록
     @PostMapping("/comment/{postId}")
     @Operation(summary = "댓글 등록", description = "댓글을 등록합니다.")
-    public ResponseEntity<ApiResponse<PostResponseDto.CommentResponseDto>> comment(
+    public ResponseEntity<ApiResponse<PostResponseDTO.CommentDTO>> comment(
             @AuthUser Long userId,
             @PathVariable Long postId,
             @RequestBody String content
     ) {
-        PostResponseDto.CommentResponseDto response = postService.createComment(userId, postId, content);
+        PostResponseDTO.CommentDTO response = postService.createComment(userId, postId, content);
 
         return ResponseEntity
                 .created(URI.create("/api/post/" + postId))
@@ -128,8 +128,8 @@ public class PostController {
     // TODO : 게시글 상세 조회
     @GetMapping("/{postId}")
     @Operation(summary = "게시글 상세 조회", description = "게시글 단건을 상세 조회합니다.")
-    public ResponseEntity<ApiResponse<PostResponseDto.PostDetailDto>> detail(@AuthUser Long userId, @PathVariable Long postId) {
-        PostResponseDto.PostDetailDto response = postService.getPostDetail(userId, postId);
+    public ResponseEntity<ApiResponse<PostResponseDTO.DetailDTO>> detail(@AuthUser Long userId, @PathVariable Long postId) {
+        PostResponseDTO.DetailDTO response = postService.getPostDetail(userId, postId);
 
         return ResponseEntity.ok()
                 .body(ApiResponse.onSuccess(response));
@@ -165,7 +165,7 @@ public class PostController {
                             description = "투표 참여 성공",
                             content = @Content(
                                     mediaType = "application/json",
-                                        schema = @Schema(implementation = PostResponseDto.VoteResponseDTO.class),
+                                        schema = @Schema(implementation = PostResponseDTO.VoteDTO.class),
                                     examples = @ExampleObject(value = """
                                                 {
                                                   "isSuccess": true,
@@ -189,11 +189,11 @@ public class PostController {
                     )
             }
     )
-    public ResponseEntity<ApiResponse<PostResponseDto.VoteResponseDTO>> vote(
+    public ResponseEntity<ApiResponse<PostResponseDTO.VoteDTO>> vote(
             @AuthUser long userId,
             @PathVariable long postId,
             @RequestBody PostRequestDto.VoteParticipationDTO voteParticipationDTO) {
-        PostResponseDto.VoteResponseDTO response = postService.vote(userId, postId, voteParticipationDTO);
+        PostResponseDTO.VoteDTO response = postService.vote(userId, postId, voteParticipationDTO);
         return ResponseEntity
                 .created(URI.create("/api/post/" + postId))
                 .body(ApiResponse.onSuccess(response));

--- a/src/main/java/com/stockpulse/stockpulseAPI/domain/post/controller/PostController.java
+++ b/src/main/java/com/stockpulse/stockpulseAPI/domain/post/controller/PostController.java
@@ -8,6 +8,7 @@ import com.stockpulse.stockpulseAPI.domain.stock.dto.StockResponseDTO;
 import com.stockpulse.stockpulseAPI.global.apiPayload.ApiResponse;
 import com.stockpulse.stockpulseAPI.global.security.handler.annotation.AuthUser;
 import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
 import io.swagger.v3.oas.annotations.enums.ParameterIn;
 import io.swagger.v3.oas.annotations.media.Content;
 import io.swagger.v3.oas.annotations.media.ExampleObject;
@@ -35,8 +36,16 @@ public class PostController {
     @Operation(summary = "게시글 목록 조회", description = "게시글 목록을 조회합니다.")
     @GetMapping("/list")
     public ResponseEntity<ApiResponse<List<PostResponseDto.PostSummaryDto>>> list(
+            @Parameter(description = "페이지 번호(0부터 시작)", example = "0")
             @RequestParam("page") int page,
+            @Parameter(description = "한 페이지 당 게시글 수", example = "10")
             @RequestParam("size") int size,
+            @Parameter(description = "정렬 기준",
+                    examples = {
+                            @ExampleObject(name = "인기순", value = "popular", summary = "투표 많은 순"),
+                            @ExampleObject(name = "댓글순", value = "comment", summary = "댓글 많은 순"),
+                            @ExampleObject(name = "최신순", value = "latest", summary = "최신 작성 순")
+                    })
             @RequestParam("sort") String sort) {
         List<PostResponseDto.PostSummaryDto> posts = postService.getPostList(page, size, sort);
         return ResponseEntity

--- a/src/main/java/com/stockpulse/stockpulseAPI/domain/post/dto/PostResponseDTO.java
+++ b/src/main/java/com/stockpulse/stockpulseAPI/domain/post/dto/PostResponseDTO.java
@@ -1,17 +1,17 @@
 package com.stockpulse.stockpulseAPI.domain.post.dto;
 
-import com.stockpulse.stockpulseAPI.domain.post.entity.Comment;
+import com.stockpulse.stockpulseAPI.domain.post.entity.Post;
 import lombok.*;
 
 import java.util.List;
 
-public class PostResponseDto {
+public class PostResponseDTO {
 
     @Builder
     @Getter
     @NoArgsConstructor
     @AllArgsConstructor
-    public static class PostSummaryDto {
+    public static class SummaryDTO {
         private Long postId;
         private String title;
         private String contentSummary;
@@ -29,13 +29,35 @@ public class PostResponseDto {
         private String stockName;
         private Long stockPrice;
         private Float stockChangeRate;
+
+        public static SummaryDTO from(Post post) {
+            String summary = post.getContent().length() <= 40 ?
+                    post.getContent() :
+                    post.getContent().substring(0, 40) + "...";
+
+            return SummaryDTO.builder()
+                    .postId(post.getId())
+                    .title(post.getTitle())
+                    .contentSummary(summary)
+                    .createdAt(post.getCreatedAt().toString())
+                    .author(post.getMember().getNickname())
+                    .commentCount(post.getCommentCount())
+                    .voteCount(post.getVoteCount())
+                    .newsImageUrl(post.getNews().getImage())
+                    .newsTitle(post.getNews().getTitle())
+                    .newsPublishedDate(post.getNews().getPublishedDate().toString())
+                    .newsPublisher(post.getNews().getPress())
+                    .stockImageUrl(post.getStock().getImageUrl())
+                    .stockName(post.getStock().getName())
+                    .build();
+        }
     }
 
-    @Builder
     @NoArgsConstructor
     @AllArgsConstructor
     @Getter
-    public static class PostDetailDto {
+    @Builder
+    public static class DetailDTO {
         private Long postId;
         private String author;
         private String updatedAt;
@@ -57,17 +79,17 @@ public class PostResponseDto {
         private boolean isStockOwned;
         private boolean isStockFavorite;
 
-        private VoteResponseDTO voteSummary;
+        private VoteDTO voteSummary;
 
         private Integer commentCount;
-        private List<CommentResponseDto> comments;
+        private List<CommentDTO> comments;
     }
 
     @Builder
     @NoArgsConstructor
     @AllArgsConstructor
     @Getter
-    public static class VoteResponseDTO{
+    public static class VoteDTO {
         private Long postId;
         private Long buy;
         private Long sell;
@@ -79,7 +101,7 @@ public class PostResponseDto {
     @Getter
     @AllArgsConstructor
     @NoArgsConstructor
-    public static class CommentResponseDto {
+    public static class CommentDTO {
         private Long commentId;
         private String content;
         private String createdAt;

--- a/src/main/java/com/stockpulse/stockpulseAPI/domain/post/service/PostService.java
+++ b/src/main/java/com/stockpulse/stockpulseAPI/domain/post/service/PostService.java
@@ -7,7 +7,7 @@ import com.stockpulse.stockpulseAPI.domain.news.entity.News;
 import com.stockpulse.stockpulseAPI.domain.news.exception.NewsException;
 import com.stockpulse.stockpulseAPI.domain.news.repository.NewsRepository;
 import com.stockpulse.stockpulseAPI.domain.post.dto.PostRequestDto;
-import com.stockpulse.stockpulseAPI.domain.post.dto.PostResponseDto;
+import com.stockpulse.stockpulseAPI.domain.post.dto.PostResponseDTO;
 import com.stockpulse.stockpulseAPI.domain.post.entity.*;
 import com.stockpulse.stockpulseAPI.domain.post.entity.enums.VoteOption;
 import com.stockpulse.stockpulseAPI.domain.post.repository.CommentRepository;
@@ -39,7 +39,7 @@ public class PostService {
     private final VoteRecordRepository voteRecordRepository;
     private final CommentRepository commentRepository;
 
-    public List<PostResponseDto.PostSummaryDto> getPostList(int page, int size, String sort) {
+    public List<PostResponseDTO.SummaryDTO> getPostList(int page, int size, String sort) {
         Sort sortOption;
 
         switch (sort.toLowerCase()) {
@@ -59,7 +59,7 @@ public class PostService {
         Page<Post> postPage = postRepository.findAll(pageable);
 
         return postPage.getContent().stream()
-                .map(post -> PostResponseDto.PostSummaryDto.builder()
+                .map(post -> PostResponseDTO.SummaryDTO.builder()
                         .postId(post.getId())
                         .title(post.getTitle())
                         .contentSummary(post.getContent().length() <= 40 ?
@@ -125,7 +125,7 @@ public class PostService {
     }
 
     @Transactional
-    public PostResponseDto.CommentResponseDto createComment(Long userId, Long postId, String content) {
+    public PostResponseDTO.CommentDTO createComment(Long userId, Long postId, String content) {
         Member member = memberRepository.findById(userId).orElseThrow(() -> new RuntimeException("Member not found")); // TODO : 커스텀 Exception 추가 필요
         Post post = postRepository.findById(postId).orElseThrow(() -> new RuntimeException("Post not found")); // TODO : 커스텀 Exception 추가 필요
 
@@ -139,7 +139,7 @@ public class PostService {
 
         post.setCommentCount(post.getCommentCount() + 1);
 
-        PostResponseDto.CommentResponseDto dto = PostResponseDto.CommentResponseDto.builder()
+        PostResponseDTO.CommentDTO dto = PostResponseDTO.CommentDTO.builder()
                 .commentId(comment.getId())
                 .content(content)
                 .createdAt(post.getCreatedAt().toString())
@@ -149,11 +149,11 @@ public class PostService {
         return dto;
     }
 
-    public PostResponseDto.PostDetailDto getPostDetail(Long userId, Long postId) {
+    public PostResponseDTO.DetailDTO getPostDetail(Long userId, Long postId) {
         Post post = postRepository.findById(postId).orElseThrow(() -> new RuntimeException("Post not found")); // TODO : 커스텀 Exception 추가 필요
         Member member = memberRepository.findById(userId).orElseThrow(() -> new RuntimeException("Member not found"));// TODO : 커스텀 Exception 추가 필요
 
-        PostResponseDto.PostDetailDto dto = PostResponseDto.PostDetailDto.builder()
+        PostResponseDTO.DetailDTO dto = PostResponseDTO.DetailDTO.builder()
                 .postId(post.getId())
                 .author(post.getMember().getNickname())
                 .updatedAt(post.getUpdatedAt().toString())
@@ -172,7 +172,7 @@ public class PostService {
                 .stockImageUrl(post.getStock().getImageUrl())
                 .isStockOwned(member.getMemberOwnStockList().contains(post.getStock()))
                 .isStockFavorite(member.getMemberFavoriteStockList().contains(post.getStock()))
-                .voteSummary(PostResponseDto.VoteResponseDTO.builder()
+                .voteSummary(PostResponseDTO.VoteDTO.builder()
                         .postId(post.getId())
                         .buy(post.getVote().getBuy())
                         .sell(post.getVote().getSell())
@@ -180,7 +180,7 @@ public class PostService {
                         .total(post.getVote().getTotal())
                         .build())
                 .commentCount(post.getCommentCount())
-                .comments(post.getComments().stream().map(comment -> PostResponseDto.CommentResponseDto.builder()
+                .comments(post.getComments().stream().map(comment -> PostResponseDTO.CommentDTO.builder()
                         .commentId(comment.getId())
                         .content(comment.getContent())
                         .createdAt(comment.getCreatedAt().toString())
@@ -193,7 +193,7 @@ public class PostService {
 
     // TODO : 투표 참여
     @Transactional
-    public PostResponseDto.VoteResponseDTO vote(Long userId, long postId, PostRequestDto.VoteParticipationDTO voteParticipationDTO) {
+    public PostResponseDTO.VoteDTO vote(Long userId, long postId, PostRequestDto.VoteParticipationDTO voteParticipationDTO) {
         Member member = memberRepository.findById(userId).orElseThrow(() -> new RuntimeException("Member not found")); // TODO : 커스텀 Exception 추가 필요
         Post post = postRepository.findById(postId).orElseThrow(() -> new RuntimeException("Post not found")); // TODO : 커스텀 Exception 추가 필요
         Vote vote = post.getVote();
@@ -227,7 +227,7 @@ public class PostService {
         post.setVoteCount(post.getVoteCount() + 1);
         vote.setTotal(vote.getTotal() + 1);
 
-        PostResponseDto.VoteResponseDTO dto = PostResponseDto.VoteResponseDTO.builder()
+        PostResponseDTO.VoteDTO dto = PostResponseDTO.VoteDTO.builder()
                 .postId(post.getId())
                 .buy(vote.getBuy())
                 .sell(vote.getSell())

--- a/src/test/java/com/stockpulse/stockpulseAPI/post/service/PostServiceTest.java
+++ b/src/test/java/com/stockpulse/stockpulseAPI/post/service/PostServiceTest.java
@@ -1,6 +1,6 @@
 package com.stockpulse.stockpulseAPI.post.service;
 
-import com.stockpulse.stockpulseAPI.domain.post.dto.PostResponseDto;
+import com.stockpulse.stockpulseAPI.domain.post.dto.PostResponseDTO;
 import com.stockpulse.stockpulseAPI.domain.post.service.PostService;
 import lombok.extern.slf4j.Slf4j;
 import org.junit.jupiter.api.DisplayName;
@@ -21,7 +21,7 @@ public class PostServiceTest {
     @Test
     @DisplayName("게시글 목록 조회")
     void getPostList() {
-        List<PostResponseDto.PostSummaryDto> latest = postService.getPostList(0, 5, "latest");
+        List<PostResponseDTO.SummaryDTO> latest = postService.getPostList(0, 5, "latest");
 
         log.info("latest = {}", latest);
     }


### PR DESCRIPTION
## 📌 작업 내용
사용자 정보, 사용자 스크랩 뉴스 API 구현, 내가 작성한 게시글 조회, 내가 댓글 단 게시글 조회

사용자가 스크랩한 뉴스를 조회하는 기능을 위해 JPQL에서 하나의 쿼리만 이용한다면, 스크랩한 뉴스를 여러개 가져오는 카데시안 문제가 발생합니다. 
쿼리를 두개의 단계로 나누어서, 첫번째 쿼리에서는 사용자가 스크랩한 뉴스 기사를 FETCH JOIN으로 가져옴으로 써 N+1 문제를 극복할 수 있었고, 두번째 쿼리에서 서브쿼리를 이용해 하나의 뉴스에 대해 영향도 값이 가장 높은 수를 갖는 종목(뉴스에 대해 가장 영향을 많이 받은 종목)을 조회하도록 쿼리를 작성하여 조회 성능을 높였습니다.

## ✨ 참고 사항

## 🧩 연관 이슈
#49


<br>