### PR TITLE
🐛[Fix] 뉴스 데이터 저장 API 호출 시, 알림 로직 실패로 모든 트랜잭션 롤백 및 API 응답 실패 문제

### DIFF
--- a/src/main/java/com/stockpulse/stockpulseAPI/domain/member/controller/MemberController.java
+++ b/src/main/java/com/stockpulse/stockpulseAPI/domain/member/controller/MemberController.java
@@ -10,6 +10,7 @@ import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.media.Content;
 import io.swagger.v3.oas.annotations.media.ExampleObject;
 import io.swagger.v3.oas.annotations.media.Schema;
+import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
@@ -19,6 +20,7 @@ import java.util.List;
 @RestController
 @RequestMapping("/api/v1/member")
 @RequiredArgsConstructor
+@Tag(name = "Member", description = "사용자 관련 API")
 public class MemberController {
 
     private final MemberService memberService;

--- a/src/main/java/com/stockpulse/stockpulseAPI/domain/member/entity/Member.java
+++ b/src/main/java/com/stockpulse/stockpulseAPI/domain/member/entity/Member.java
@@ -1,6 +1,7 @@
 package com.stockpulse.stockpulseAPI.domain.member.entity;
 
 import com.stockpulse.stockpulseAPI.domain.common.BaseEntity;
+import com.stockpulse.stockpulseAPI.domain.member.service.event.MemberEntityListener;
 import com.stockpulse.stockpulseAPI.domain.news.entity.MemberScrapNews;
 import com.stockpulse.stockpulseAPI.domain.notification.entity.FcmToken;
 import com.stockpulse.stockpulseAPI.domain.notification.entity.Notification;

--- a/src/main/java/com/stockpulse/stockpulseAPI/domain/member/service/event/MemberCreatedEvent.java
+++ b/src/main/java/com/stockpulse/stockpulseAPI/domain/member/service/event/MemberCreatedEvent.java
@@ -1,4 +1,4 @@
-package com.stockpulse.stockpulseAPI.domain.member.entity;
+package com.stockpulse.stockpulseAPI.domain.member.service.event;
 
 import lombok.Getter;
 

--- a/src/main/java/com/stockpulse/stockpulseAPI/domain/member/service/event/MemberEntityListener.java
+++ b/src/main/java/com/stockpulse/stockpulseAPI/domain/member/service/event/MemberEntityListener.java
@@ -1,5 +1,6 @@
-package com.stockpulse.stockpulseAPI.domain.member.entity;
+package com.stockpulse.stockpulseAPI.domain.member.service.event;
 
+import com.stockpulse.stockpulseAPI.domain.member.entity.Member;
 import jakarta.persistence.PostPersist;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.context.ApplicationEventPublisher;

--- a/src/main/java/com/stockpulse/stockpulseAPI/domain/notification/controller/FcmTokenController.java
+++ b/src/main/java/com/stockpulse/stockpulseAPI/domain/notification/controller/FcmTokenController.java
@@ -3,6 +3,7 @@ package com.stockpulse.stockpulseAPI.domain.notification.controller;
 import com.stockpulse.stockpulseAPI.domain.notification.dto.FcmTokenRequestDto;
 import com.stockpulse.stockpulseAPI.domain.notification.service.FcmTokenservice;
 import com.stockpulse.stockpulseAPI.global.security.handler.annotation.AuthUser;
+import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.PostMapping;
@@ -17,6 +18,7 @@ import static org.springframework.web.servlet.function.ServerResponse.ok;
 @RestController
 @RequiredArgsConstructor
 @RequestMapping("/api/v1/fcm")
+@Tag(name = "FCM 알림 토큰", description = "FCM 알림 토큰 API")
 public class FcmTokenController {
 
     // TODO : service 클래스

--- a/src/main/java/com/stockpulse/stockpulseAPI/domain/notification/controller/NotificationController.java
+++ b/src/main/java/com/stockpulse/stockpulseAPI/domain/notification/controller/NotificationController.java
@@ -5,6 +5,7 @@ import com.stockpulse.stockpulseAPI.domain.notification.service.NotificationServ
 import com.stockpulse.stockpulseAPI.global.apiPayload.ApiResponse;
 import com.stockpulse.stockpulseAPI.global.security.handler.annotation.AuthUser;
 import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.websocket.server.PathParam;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
@@ -18,6 +19,7 @@ import java.util.List;
 @RestController
 @RequiredArgsConstructor
 @RequestMapping("/api/v1/notification")
+@Tag(name = "Notification", description = "알림 이력 조회 관련 API")
 public class NotificationController {
     private final NotificationService notificationService;
 

--- a/src/main/java/com/stockpulse/stockpulseAPI/domain/notification/controller/NotificationSettingController.java
+++ b/src/main/java/com/stockpulse/stockpulseAPI/domain/notification/controller/NotificationSettingController.java
@@ -9,6 +9,7 @@ import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.media.Content;
 import io.swagger.v3.oas.annotations.media.ExampleObject;
 import io.swagger.v3.oas.annotations.media.Schema;
+import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
@@ -16,6 +17,7 @@ import org.springframework.web.bind.annotation.*;
 @RestController
 @RequestMapping("/notification/setting")
 @RequiredArgsConstructor
+@Tag(name = "NotificationSetting", description = "알림 설정 관련 API")
 public class NotificationSettingController {
 
     private final NotificationService notificationService;

--- a/src/main/java/com/stockpulse/stockpulseAPI/domain/notification/service/NotificationService.java
+++ b/src/main/java/com/stockpulse/stockpulseAPI/domain/notification/service/NotificationService.java
@@ -20,7 +20,10 @@ import com.stockpulse.stockpulseAPI.domain.stock.repository.MemberFavoriteStockR
 import lombok.RequiredArgsConstructor;
 import org.springframework.context.event.EventListener;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Propagation;
 import org.springframework.transaction.annotation.Transactional;
+import org.springframework.transaction.event.TransactionPhase;
+import org.springframework.transaction.event.TransactionalEventListener;
 
 import java.math.BigDecimal;
 import java.util.List;
@@ -67,8 +70,10 @@ public class NotificationService {
     }
 
 
-    @EventListener
-    @Transactional
+    @TransactionalEventListener(phase = TransactionPhase.AFTER_COMMIT)
+    @Transactional(propagation = Propagation.REQUIRES_NEW) // 새로운 트랜잭션을 시작하도록 변경@TransactionalEventListener(phase = TransactionPhase.AFTER_COMMIT)
+//    @EventListener
+//    @Transactional
     public void handleImpactSavedEvent(ImpactSavedEvent event) {
         notification(event.getImpacts());
     }

--- a/src/main/java/com/stockpulse/stockpulseAPI/domain/notification/service/handler/NotificationEventHandler.java
+++ b/src/main/java/com/stockpulse/stockpulseAPI/domain/notification/service/handler/NotificationEventHandler.java
@@ -1,6 +1,6 @@
 package com.stockpulse.stockpulseAPI.domain.notification.service.handler;
 
-import com.stockpulse.stockpulseAPI.domain.member.entity.MemberCreatedEvent;
+import com.stockpulse.stockpulseAPI.domain.member.service.event.MemberCreatedEvent;
 import com.stockpulse.stockpulseAPI.domain.notification.service.NotificationService;
 import org.springframework.stereotype.Component;
 import org.springframework.transaction.annotation.Propagation;

--- a/src/main/java/com/stockpulse/stockpulseAPI/global/security/controller/AuthController.java
+++ b/src/main/java/com/stockpulse/stockpulseAPI/global/security/controller/AuthController.java
@@ -6,6 +6,7 @@ import com.stockpulse.stockpulseAPI.global.apiPayload.code.status.SuccessStatus;
 import com.stockpulse.stockpulseAPI.global.security.authDTO.AuthResponseDTO;
 import com.stockpulse.stockpulseAPI.global.security.handler.annotation.AuthUser;
 import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.servlet.http.HttpServletRequest;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
@@ -14,6 +15,7 @@ import org.springframework.web.bind.annotation.*;
 @RestController
 @RequiredArgsConstructor
 @RequestMapping("/api/auth")
+@Tag(name = "OAuth2", description = "OAuth2 API")
 public class AuthController {
 
     private final AuthService authService;


### PR DESCRIPTION
## 📌 작업 내용
뉴스 데이터 저장과 알림 저장 간에 트랜잭션 하나로 결합되는 문제가 있었습니다. 
> @TransactionalEventListener(phase = TransactionPhase.AFTER_COMMIT)
> @Transactional(propagation = Propagation.REQUIRES_NEW)
두 어노테이션을 이용하여 두개의 트랜잭션으로 각각 분리하였습니다.

## ✨ 참고 사항

## 🧩 연관 이슈
#55 

<br>