### PR TITLE
♻️[Refactor] 뉴스 데이터 파이프라인 동일 기사, 종목 쌍 저장 방지 로직 추가

### DIFF
--- a/src/main/java/com/stockpulse/stockpulseAPI/domain/news/controller/NewsController.java
+++ b/src/main/java/com/stockpulse/stockpulseAPI/domain/news/controller/NewsController.java
@@ -11,6 +11,7 @@ import io.swagger.v3.oas.annotations.media.Content;
 import io.swagger.v3.oas.annotations.media.ExampleObject;
 import io.swagger.v3.oas.annotations.media.Schema;
 import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.validation.constraints.Min;
 import lombok.RequiredArgsConstructor;
 import org.springframework.web.bind.annotation.*;
 
@@ -264,6 +265,26 @@ public class NewsController {
             @AuthUser Long memberId
     ) {
         List<NewsResponseDTO.MyLatestNewsDTO> result = newsQueryService.getMyLatestNews(memberId);
+        return ApiResponse.onSuccess(result);
+    }
+
+    @Operation(
+            summary = "특정 종목 최신 뉴스 조회 API",
+            description = """
+    특정 종목과 연관있는 뉴스를 조회합니다.
+    - Parameter:
+      - `page`: 페이지 번호 (1부터 시작)
+      - `size`: 한 페이지당 게시글 개수 (기본값: 10)
+    """
+    )
+    @GetMapping("/{stockId}/latest")
+    public ApiResponse<List<NewsResponseDTO.NewsDTO>> getStockLatestNews(
+            @AuthUser Long memberId,
+            @PathVariable("stockId") Long stockId,
+            @RequestParam(name = "page", defaultValue = "1") @Min(1)Integer page,
+            @RequestParam(name = "size", defaultValue = "10") @Min(1)Integer size
+    ) {
+        List<NewsResponseDTO.NewsDTO> result = newsQueryService.getStockLatestNews(stockId, memberId, page, size);
         return ApiResponse.onSuccess(result);
     }
 }

--- a/src/main/java/com/stockpulse/stockpulseAPI/domain/news/entity/Impact.java
+++ b/src/main/java/com/stockpulse/stockpulseAPI/domain/news/entity/Impact.java
@@ -31,4 +31,8 @@ public class Impact extends BaseEntity {
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "stock_id", nullable = false)
     private Stock stock;
+
+    public void updateImpactRate(BigDecimal newImpactRate) {
+        this.impactRate = newImpactRate;
+    }
 }

--- a/src/main/java/com/stockpulse/stockpulseAPI/domain/news/repository/ImpactRepository.java
+++ b/src/main/java/com/stockpulse/stockpulseAPI/domain/news/repository/ImpactRepository.java
@@ -46,4 +46,12 @@ public interface ImpactRepository extends JpaRepository<Impact, Long> {
         AND DATE(n.publishedDate) = CURRENT_DATE
         """)
     List<Impact> findTodayImpactsByStock(@Param("stock") Stock stock);
+
+    @Query("""
+        SELECT i FROM Impact i 
+        JOIN FETCH i.news n 
+        WHERE i.stock = :stock 
+        ORDER BY n.publishedDate DESC
+        """)
+    List<Impact> findByStockOrderByNewsPublishedDateDesc(@Param("stock") Stock stock, Pageable pageable);
 }

--- a/src/main/java/com/stockpulse/stockpulseAPI/domain/news/service/NewsCommandService.java
+++ b/src/main/java/com/stockpulse/stockpulseAPI/domain/news/service/NewsCommandService.java
@@ -98,12 +98,20 @@ public class NewsCommandService {
         List<Impact> impacts = new ArrayList<>();
         for (NewsRequestDTO.NewsRelatedStocksDataDTO data : request) {
             stockRepository.findBySymbol(data.getSymbol()).ifPresent(stock -> {
-                Impact newImpact = Impact.builder()
-                        .stock(stock)
-                        .news(news)
-                        .impactRate(data.getInfluenceScore())
-                        .build();
-                impacts.add(newImpact);
+                Optional<Impact> existingImpact = impactRepository.findByNewsAndStock(news, stock);
+                
+                Impact impact;
+                if (existingImpact.isPresent()) {
+                    impact = existingImpact.get();
+                    impact.updateImpactRate(data.getInfluenceScore());
+                } else {
+                    impact = Impact.builder()
+                            .stock(stock)
+                            .news(news)
+                            .impactRate(data.getInfluenceScore())
+                            .build();
+                }
+                impacts.add(impact);
             });
         }
         impactRepository.saveAll(impacts);

--- a/src/main/java/com/stockpulse/stockpulseAPI/domain/news/service/NewsQueryService.java
+++ b/src/main/java/com/stockpulse/stockpulseAPI/domain/news/service/NewsQueryService.java
@@ -16,10 +16,12 @@ import com.stockpulse.stockpulseAPI.domain.stock.entity.MemberFavoriteStock;
 import com.stockpulse.stockpulseAPI.domain.stock.entity.MemberOwnStock;
 import com.stockpulse.stockpulseAPI.domain.stock.entity.Stock;
 import com.stockpulse.stockpulseAPI.domain.stock.entity.StockTick;
+import com.stockpulse.stockpulseAPI.domain.stock.repository.StockRepository;
 import com.stockpulse.stockpulseAPI.domain.stock.repository.StockTickRepository;
 import com.stockpulse.stockpulseAPI.global.apiPayload.code.status.ErrorStatus;
 import com.stockpulse.stockpulseAPI.global.apiPayload.exception.handler.MemberHandler;
 import com.stockpulse.stockpulseAPI.global.apiPayload.exception.handler.NewsHandler;
+import com.stockpulse.stockpulseAPI.global.apiPayload.exception.handler.StockHandler;
 import lombok.RequiredArgsConstructor;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.data.domain.PageRequest;
@@ -44,6 +46,7 @@ public class NewsQueryService {
 
     private final NewsRepository newsRepository;
     private final MemberRepository memberRepository;
+    private final StockRepository stockRepository;
     private final StockTickRepository stockTickRepository;
     private final ImpactRepository impactRepository;
     private final MemberScrapNewsRepository memberScrapNewsRepository;
@@ -226,6 +229,38 @@ public class NewsQueryService {
                     
                     Stock maxImpactStock = maxImpact != null ? maxImpact.getStock() : null;
                     return toMyLatestNewsDTO(news, maxImpactStock, maxImpact, sentiment);
+                })
+                .collect(Collectors.toList());
+    }
+
+    // 특정 종목의 최신 뉴스 조회
+    public List<NewsResponseDTO.NewsDTO> getStockLatestNews(Long stockId, Long memberId, int page, int size) {
+        Stock stock = stockRepository.findById(stockId)
+                .orElseThrow(() -> new StockHandler(ErrorStatus.STOCK_NOT_FOUND));
+        
+        Member member = memberRepository.findById(memberId)
+                .orElseThrow(() -> new MemberHandler(ErrorStatus.MEMBER_NOT_FOUND));
+                
+        Pageable pageable = PageRequest.of(page - 1, size);
+        List<Impact> impacts = impactRepository.findByStockOrderByNewsPublishedDateDesc(stock, pageable);
+        
+        return impacts.stream()
+                .map(Impact::getNews)
+                .distinct()
+                .map(news -> {
+                    boolean scrapped = memberScrapNewsRepository.findByMemberAndNews(member, news).isPresent();
+                    
+                    Impact targetStockImpact = news.getImpacts().stream()
+                            .filter(impact -> impact.getStock().equals(stock))
+                            .findFirst()
+                            .orElse(null);
+                    
+                    Sentiment sentiment = targetStockImpact != null ? determineSentiment(targetStockImpact) : Sentiment.NEUTRAL;
+                    
+                    NewsResponseDTO.NewsDetailStockDTO stockInfo = targetStockImpact != null ? 
+                            createStockInfoWithTick(stock, targetStockImpact, 1) : null;
+                    
+                    return toNewsDTO(news, scrapped, sentiment, stockInfo);
                 })
                 .collect(Collectors.toList());
     }

--- a/src/main/java/com/stockpulse/stockpulseAPI/domain/notification/service/NotificationService.java
+++ b/src/main/java/com/stockpulse/stockpulseAPI/domain/notification/service/NotificationService.java
@@ -101,7 +101,9 @@ public class NotificationService {
                     .orElseThrow(() -> new IllegalArgumentException("종목에 관심한 사용가 존재하지 않습니다."));
             for (Member member : members) {
                 // 3. 사용자의 알림 세팅 조회
-                NotificationSetting setting = notificationSettingRepository.findByMember(member).orElseThrow(() -> new IllegalArgumentException("알림 세팅이 존재하지 않습니다."));
+                NotificationSetting setting
+                        = notificationSettingRepository.findByMember(member).orElseThrow(()
+                        -> new IllegalArgumentException("알림 세팅이 존재하지 않습니다."));
 
                 boolean sendNotification = false;
 


### PR DESCRIPTION
## 📌 작업 내용

> - 뉴스 데이터 파이프라인 데이터 공급 시에 동일 기사, 동일 종목 쌍이 중복으로 들어오는 경우 저장을 방지하는 로직을 추가했습니다.
> - 특정 종목 최신 뉴스 조회 API를 구현했습니다.

## ✨ 참고 사항

> 코드 리뷰 시 참고할 만한 사항이나 주의할 점을 작성해주세요.

## 🧩 연관 이슈

> 이 PR과 연관된 이슈 번호를 작성하세요. 예) close #57


<br>