### PR TITLE
♻️[Refactor] 뉴스 데이터 파이프라인 동일 기사 저장 방지 로직 수정

### DIFF
--- a/src/main/java/com/stockpulse/stockpulseAPI/domain/news/repository/NewsRepository.java
+++ b/src/main/java/com/stockpulse/stockpulseAPI/domain/news/repository/NewsRepository.java
@@ -17,6 +17,7 @@ public interface NewsRepository extends JpaRepository<News, Long>, NewsRepositor
     boolean existsByUrl(String url);
 
     Optional<News> findByUrl(String url);
+    Optional<News> findByContent(String content);
 
     @Query("SELECT n FROM News n LEFT JOIN FETCH n.impacts WHERE n.id = :id")
     Optional<News> findByIdWithImpacts(@Param("id") Long id);

--- a/src/main/java/com/stockpulse/stockpulseAPI/domain/news/service/NewsCommandService.java
+++ b/src/main/java/com/stockpulse/stockpulseAPI/domain/news/service/NewsCommandService.java
@@ -69,8 +69,8 @@ public class NewsCommandService {
     }
 
     private void processNewsData(NewsRequestDTO.NewsDataPostRequestDTO request) {
-        Optional<News> existingNews = newsRepository.findByUrl(request.getNewsUrl());
-        
+        Optional<News> existingNews = newsRepository.findByContent(request.getContent());
+
         News news;
         if(existingNews.isEmpty()){
             news = createNewsFromRequest(request);
@@ -78,7 +78,6 @@ public class NewsCommandService {
         } else {
             news = existingNews.get();
         }
-        
         saveImpactFromNewsData(news, request.getRelatedStocks());
     }
 


### PR DESCRIPTION
## 📌 작업 내용

> 중복 뉴스의 경우 서로 다른 url 이라도 같은 기사로 리다이렉트 되는 현상을 확인했습니다.
> 이에 따라 뉴스 데이터 파이프라인 동일 기사 저장 방지 로직을 url 기반에서 내용 기반으로 수정했습니다.
## ✨ 참고 사항

> 

## 🧩 연관 이슈

> close #65 


<br>