### PR TITLE
♻️[Refactor] 종목코드 6자리 패딩 처리

### DIFF
--- a/src/main/java/com/stockpulse/stockpulseAPI/domain/news/service/NewsCommandService.java
+++ b/src/main/java/com/stockpulse/stockpulseAPI/domain/news/service/NewsCommandService.java
@@ -96,7 +96,13 @@ public class NewsCommandService {
     private void saveImpactFromNewsData(News news, List<NewsRequestDTO.NewsRelatedStocksDataDTO> request) {
         List<Impact> impacts = new ArrayList<>();
         for (NewsRequestDTO.NewsRelatedStocksDataDTO data : request) {
-            stockRepository.findBySymbol(data.getSymbol()).ifPresent(stock -> {
+
+            String symbol = data.getSymbol();
+            if (symbol.length() != 6) {
+                symbol = String.format("%06d", Integer.parseInt(symbol));
+            }
+
+            stockRepository.findBySymbol(symbol).ifPresent(stock -> {
                 Optional<Impact> existingImpact = impactRepository.findByNewsAndStock(news, stock);
                 
                 Impact impact;


### PR DESCRIPTION
## 📌 작업 내용

> 종목 코드의 자릿수를 항상 6자리로(코스피)로 맞추도록 수정했습니다

## ✨ 참고 사항

> 

## 🧩 연관 이슈

> 


<br>